### PR TITLE
Fix Snake self-kill from rapid perpendicular-then-reverse input

### DIFF
--- a/src/games/snake/controls.js
+++ b/src/games/snake/controls.js
@@ -1,3 +1,5 @@
+import { setDirection } from './logic.js';
+
 const DIR_MAP = {
   ArrowUp:    { x:  0, y: -1 },
   ArrowDown:  { x:  0, y:  1 },
@@ -17,11 +19,7 @@ export function bindControls(getState, setState) {
     e.preventDefault();
     const state = getState();
     if (!state.alive) return;
-    setState(s => {
-      // Prevent 180° turn
-      if (dir.x === -s.dir.x && dir.y === -s.dir.y) return s;
-      return { ...s, nextDir: dir };
-    });
+    setState(s => setDirection(s, dir));
   }
 
   document.addEventListener('keydown', onKeyDown);
@@ -45,10 +43,7 @@ export function bindTouchControls(container, getState, setState) {
     btn.addEventListener('touchstart', e => {
       e.preventDefault();
       const dir = { x: +btn.dataset.x, y: +btn.dataset.y };
-      setState(s => {
-        if (dir.x === -s.dir.x && dir.y === -s.dir.y) return s;
-        return { ...s, nextDir: dir };
-      });
+      setState(s => setDirection(s, dir));
     }, { passive: false });
   });
 

--- a/src/games/snake/logic.js
+++ b/src/games/snake/logic.js
@@ -51,8 +51,8 @@ export function tick(state) {
 }
 
 export function setDirection(state, newDir) {
-  // Prevent 180° turn
-  if (newDir.x === -state.dir.x && newDir.y === -state.dir.y) return state;
+  // Check against nextDir, not dir: a perpendicular-then-reverse input within one tick would otherwise overwrite the buffered turn and self-kill.
+  if (newDir.x === -state.nextDir.x && newDir.y === -state.nextDir.y) return state;
   return { ...state, nextDir: newDir };
 }
 


### PR DESCRIPTION
## Summary
- Snake's `setDirection` checked the new direction against `state.dir` (the currently active direction) rather than `state.nextDir` (the buffered intent). Two presses inside one tick — e.g. Up then Down while heading right — overwrote the buffered Up with Down and steered the snake into its own neck.
- Compare against `nextDir`. Route keyboard and touch input through `setDirection` so the rule lives in one place.

Closes #1

## Test plan
Verified in-browser via `setDirection` unit-style scenarios:

- [x] Right → Up → Down: nextDir stays Up (Down rejected)
- [x] Right → Left: nextDir stays Right (180° rejected)
- [x] Right → Up: nextDir = Up (perpendicular allowed)
- [x] Right → Up → Up: nextDir = Up (idempotent)
- [ ] Manual: hold rapid alternating arrow keys, snake never reverses through itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)