### PR TITLE
Add pause function to Tetris and Snake

### DIFF
--- a/src/games/snake/controls.js
+++ b/src/games/snake/controls.js
@@ -11,9 +11,17 @@ const DIR_MAP = {
   d: { x:  1, y:  0 },
 };
 
-export function bindControls(getState, setState) {
+const PAUSE_KEYS = new Set(['p','P','Escape']);
+
+export function bindControls(callbacks, getState, setState) {
   function onKeyDown(e) {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.closest('dialog[open]')) return;
+    if (e.repeat) return;
+    if (PAUSE_KEYS.has(e.key)) {
+      e.preventDefault();
+      callbacks.pause?.();
+      return;
+    }
     const dir = DIR_MAP[e.key];
     if (!dir) return;
     e.preventDefault();

--- a/src/games/tetris/controls.js
+++ b/src/games/tetris/controls.js
@@ -1,7 +1,7 @@
 const DAS_DELAY  = 170;
 const DAS_REPEAT = 50;
 
-export function bindControls(loop, getState, dispatch) {
+export function bindControls(callbacks, getState, dispatch) {
   let dasKey = null;
   let dasTimer = null;
 
@@ -21,10 +21,16 @@ export function bindControls(loop, getState, dispatch) {
   };
 
   const dasKeys = new Set(['ArrowLeft','ArrowRight','a','d']);
+  const pauseKeys = new Set(['p','P','Escape']);
 
   function onKeyDown(e) {
-    if (e.repeat) return;
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.closest('dialog[open]')) return;
+    if (e.repeat) return;
+    if (pauseKeys.has(e.key)) {
+      e.preventDefault();
+      callbacks.pause?.();
+      return;
+    }
     const action = keyMap[e.key];
     if (!action) return;
     e.preventDefault();

--- a/src/pages/snake.js
+++ b/src/pages/snake.js
@@ -20,6 +20,7 @@ export function mount(container) {
       <div class="game-layout">
         <div class="game-area">
           <canvas id="snake-canvas" width="${CANVAS_SIZE}" height="${CANVAS_SIZE}"></canvas>
+          <div class="pause-overlay hidden" id="snake-pause">⏸ Pause</div>
           <div class="game-over-overlay hidden" id="snake-over">
             <h2>Game Over</h2>
             <p>Score: <strong id="final-score"></strong></p>
@@ -45,11 +46,21 @@ export function mount(container) {
 
   const canvas  = document.getElementById('snake-canvas');
   const overlay = document.getElementById('snake-over');
+  const pauseOverlay = document.getElementById('snake-pause');
+
+  function togglePause() {
+    if (gameOver) return;
+    paused = !paused;
+    pauseOverlay.classList.toggle('hidden', !paused);
+  }
 
   function getState() { return state; }
-  function setState(updater) { state = updater(state); }
+  function setState(updater) {
+    if (paused || gameOver) return;
+    state = updater(state);
+  }
 
-  cleanupControls = bindControls(getState, setState);
+  cleanupControls = bindControls({ pause: togglePause }, getState, setState);
   cleanupTouch = bindTouchControls(container.querySelector('.game-area'), getState, setState);
 
   function loop(timestamp) {

--- a/src/pages/tetris.js
+++ b/src/pages/tetris.js
@@ -20,6 +20,7 @@ export function mount(container) {
       <div class="game-layout">
         <div class="game-area">
           <canvas id="tetris-canvas" width="${CANVAS_W}" height="${CANVAS_H}"></canvas>
+          <div class="pause-overlay hidden" id="tetris-pause">⏸ Pause</div>
           <div class="game-over-overlay hidden" id="tetris-over">
             <h2>Game Over</h2>
             <p>Score: <strong id="final-score"></strong></p>
@@ -59,6 +60,13 @@ export function mount(container) {
   const nextCanvas = document.getElementById('next-canvas');
   const holdCanvas = document.getElementById('hold-canvas');
   const overlay   = document.getElementById('tetris-over');
+  const pauseOverlay = document.getElementById('tetris-pause');
+
+  function togglePause() {
+    if (gameOver) return;
+    paused = !paused;
+    pauseOverlay.classList.toggle('hidden', !paused);
+  }
 
   function updateStats() {
     document.getElementById('score-val').textContent = state.score.toLocaleString('de-DE');
@@ -77,7 +85,7 @@ export function mount(container) {
   }
 
   cleanupControls = bindControls(
-    { pause: () => { paused = !paused; } },
+    { pause: togglePause },
     () => state,
     dispatchAction
   );

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -184,6 +184,22 @@ a:hover { text-decoration: underline; }
 .start-overlay p { color: var(--text-muted); }
 .start-overlay.hidden { display: none; }
 
+.pause-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  background: rgba(10,10,15,0.7);
+  border-radius: 4px;
+  color: var(--text);
+  user-select: none;
+}
+.pause-overlay.hidden { display: none; }
+
 /* ===== Sidebar ===== */
 .game-sidebar {
   flex: 1;


### PR DESCRIPTION
## Summary
Both games already had a `paused` flag in their loop but no way to flip it from the keyboard. Tetris's controls received a callback as the first argument that the handler ignored; Snake had no binding at all.

- Bind `P` / `Escape` to a `pause` callback in both `controls.js` handlers (`e.repeat` filtered so holding the key doesn't toggle).
- Each page wires the callback to a `togglePause` that flips the local flag and toggles a new `.pause-overlay` element.
- Snake's `setState` wrapper drops input while paused or game over so direction changes don't leak past the overlay.

Closes #2

## Test plan
- [x] Tetris: `P` toggles overlay; loop pauses
- [x] Snake: `P` and `Escape` toggle overlay; tick pauses
- [x] Pause is ignored once Game Over has fired
- [ ] Manual: hold `P`, overlay should not flicker (`e.repeat` filter)
- [ ] Manual: pressing `P` while typing in the auth modal does not pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)