### PR TITLE
fix: show config-error banner when Supabase env vars are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ cd claude-game
 npm install
 cp .env.example .env
 # .env mit den eigenen Supabase-Credentials befüllen
+# Ohne befüllte .env startet die App im Konfigurations-Fehler-Modus und zeigt einen entsprechenden Banner.
 npm run dev
 ```
 
@@ -171,7 +172,7 @@ Bei Viewport-Breite ≤ 700 px wird ein Touch-D-Pad eingeblendet.
 2. `dist/` wird via `peaceiris/actions-gh-pages` nach `gh-pages` gepusht.
 3. GitHub Pages serviert von dort.
 
-In den Repo-Settings müssen unter **Settings → Secrets and variables → Actions → Variables** die beiden Variablen `SUPABASE_URL` und `SUPABASE_ANON_KEY` gesetzt sein.
+In den Repo-Settings müssen unter **Settings → Secrets and variables → Actions → Variables** die beiden Variablen `SUPABASE_URL` und `SUPABASE_ANON_KEY` gesetzt sein. Sind die Variablen nicht gesetzt, baut die App trotzdem fehlerfrei durch – sie startet dann im Konfigurations-Fehler-Modus und zeigt einen entsprechenden Banner.
 
 > **Hinweis:** `vite.config.js` setzt `base: '/claude-game/'`. Bei Fork mit anderem Repo-Namen muss dieser Wert angepasst werden, sonst brechen alle relativen Asset-Pfade auf Pages.
 

--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -3,10 +3,16 @@ import { createClient } from '@supabase/supabase-js';
 const url = import.meta.env.VITE_SUPABASE_URL;
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(url, key, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
-  },
-});
+export const isSupabaseConfigured =
+  typeof url === 'string' && url.length > 0 &&
+  typeof key === 'string' && key.length > 0;
+
+export const supabase = isSupabaseConfigured
+  ? createClient(url, key, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+      },
+    })
+  : null;

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { initNav } from './ui/nav.js';
+import { isSupabaseConfigured } from './api/supabase.js';
 
 const app = document.getElementById('app');
 let currentDestroy = null;
@@ -24,7 +25,34 @@ async function router() {
   currentDestroy = mod.mount(app);
 }
 
+function renderConfigBanner() {
+  const section = document.createElement('section');
+  section.className = 'config-error';
+
+  const heading = document.createElement('h1');
+  heading.textContent = 'Konfiguration fehlt';
+
+  const body = document.createElement('p');
+  body.textContent =
+    'Die Supabase-Zugangsdaten sind nicht gesetzt. Bitte `.env` aus `.env.example` anlegen und mit den eigenen Credentials befüllen. Details in der README.';
+
+  const pre = document.createElement('pre');
+  const code = document.createElement('code');
+  code.textContent = 'VITE_SUPABASE_URL=...\nVITE_SUPABASE_ANON_KEY=...';
+  pre.appendChild(code);
+
+  section.appendChild(heading);
+  section.appendChild(body);
+  section.appendChild(pre);
+  app.appendChild(section);
+}
+
 async function init() {
+  if (!isSupabaseConfigured) {
+    renderConfigBanner();
+    return;
+  }
+
   initNav();
   window.addEventListener('hashchange', router);
   await router();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -166,6 +166,24 @@ a:hover { text-decoration: underline; }
 .game-over-overlay h2 { font-size: 2rem; }
 .save-status { color: var(--accent2); font-size: 0.9rem; min-height: 1.2em; }
 
+/* ===== Start Overlay ===== */
+.start-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: rgba(10,10,15,0.75);
+  border-radius: 4px;
+  text-align: center;
+  padding: 1.5rem;
+}
+.start-overlay h2 { font-size: 2rem; }
+.start-overlay p { color: var(--text-muted); }
+.start-overlay.hidden { display: none; }
+
 /* ===== Sidebar ===== */
 .game-sidebar {
   flex: 1;
@@ -304,6 +322,30 @@ dialog::backdrop {
 }
 .dpad-btn.wide { width: 120px; font-size: 0.85rem; }
 .dpad-btn:active { background: var(--accent); }
+
+/* ===== Config Error Banner ===== */
+.config-error {
+  max-width: 560px;
+  margin: 4rem auto;
+  padding: 2rem;
+  background: var(--surface);
+  border: 2px solid var(--accent);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.config-error h1 { font-size: 1.5rem; color: var(--text); }
+.config-error p  { color: var(--text-muted); line-height: 1.6; }
+.config-error pre {
+  background: var(--surface2);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: var(--radius);
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: var(--accent2);
+  overflow-x: auto;
+}
 
 /* ===== Responsive ===== */
 @media (max-width: 700px) {


### PR DESCRIPTION
Closes #10

## Summary

- `supabase.js` now exports `isSupabaseConfigured` (boolean) and returns `null` instead of calling `createClient()` when either env var is absent — no more synchronous throw on startup.
- `main.js` checks `isSupabaseConfigured` at the very top of `init()`, renders a styled German-language banner via `createElement`/`textContent` (no `innerHTML`), and returns early — Nav and Router are never mounted.
- `.config-error` CSS class added to `main.css` using only `var(--*)` custom properties, matching the existing card pattern.

## Test plan

- [ ] **Test 1 — no `.env`**: `npm run dev` without any `.env` file → banner "Konfiguration fehlt" visible, no Supabase errors in console, `#nav` not rendered.
- [ ] **Test 2 — stub values**: `cp .env.example .env` with `VITE_SUPABASE_URL=https://example.supabase.co` and `VITE_SUPABASE_ANON_KEY=eyJ-stub` → Home page renders normally (Supabase requests may fail, but that is expected with invalid creds).
- [ ] **Test 3 — one var missing**: `.env` with only `VITE_SUPABASE_URL` set → banner visible.
- [ ] **Test 4 — production bundle**: `npm run build && npm run preview` without `.env` → banner visible in the production build.
- [ ] **Network tab**: No requests to `undefined.supabase.co` in any failing scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>