### PR TITLE
feat: add start gate — games wait for first input before running

### DIFF
--- a/src/games/snake/controls.js
+++ b/src/games/snake/controls.js
@@ -1,4 +1,4 @@
-import { setDirection } from './logic.js';
+import { start } from './logic.js';
 
 const DIR_MAP = {
   ArrowUp:    { x:  0, y: -1 },
@@ -27,7 +27,12 @@ export function bindControls(callbacks, getState, setState) {
     e.preventDefault();
     const state = getState();
     if (!state.alive) return;
-    setState(s => setDirection(s, dir));
+    setState(start);
+    setState(s => {
+      // Prevent 180° turn
+      if (dir.x === -s.dir.x && dir.y === -s.dir.y) return s;
+      return { ...s, nextDir: dir };
+    });
   }
 
   document.addEventListener('keydown', onKeyDown);
@@ -51,7 +56,11 @@ export function bindTouchControls(container, getState, setState) {
     btn.addEventListener('touchstart', e => {
       e.preventDefault();
       const dir = { x: +btn.dataset.x, y: +btn.dataset.y };
-      setState(s => setDirection(s, dir));
+      setState(start);
+      setState(s => {
+        if (dir.x === -s.dir.x && dir.y === -s.dir.y) return s;
+        return { ...s, nextDir: dir };
+      });
     }, { passive: false });
   });
 

--- a/src/games/snake/logic.js
+++ b/src/games/snake/logic.js
@@ -4,17 +4,25 @@ export function createState() {
   const snake = [{ x: 10, y: 10 }, { x: 9, y: 10 }, { x: 8, y: 10 }];
   return {
     snake,
-    dir:     { x: 1, y: 0 },
-    nextDir: { x: 1, y: 0 },
-    food:    spawnFood(snake),
-    score:   0,
-    speed:   150,
-    alive:   true,
-    startTime: Date.now(),
+    dir:       { x: 1, y: 0 },
+    nextDir:   { x: 1, y: 0 },
+    food:      spawnFood(snake),
+    score:     0,
+    speed:     150,
+    alive:     true,
+    started:   false,
+    startTime: null,
   };
 }
 
+// Idempotent: first direction input starts the clock
+export function start(state) {
+  if (state.started) return state;
+  return { ...state, started: true, startTime: Date.now() };
+}
+
 export function tick(state) {
+  if (!state.started) return state;
   if (!state.alive) return state;
 
   const dir = state.nextDir;

--- a/src/games/tetris/logic.js
+++ b/src/games/tetris/logic.js
@@ -56,11 +56,12 @@ export function createState() {
     holdUsed: false,
     bag,
     nextBag,
-    score: 0,
-    level: 0,
-    lines: 0,
-    alive: true,
-    startTime: Date.now(),
+    score:     0,
+    level:     0,
+    lines:     0,
+    alive:     true,
+    started:   false,
+    startTime: null,
   };
 }
 

--- a/src/games/tetris/logic.js
+++ b/src/games/tetris/logic.js
@@ -191,6 +191,12 @@ function lockPiece(state) {
   };
 }
 
+// Idempotent: first player action starts the clock
+export function start(state) {
+  if (state.started) return state;
+  return { ...state, started: true, startTime: Date.now() };
+}
+
 export function getGhostY(state) {
   let dy = 0;
   while (!collides(state.board, state.current.shape, state.current.x, state.current.y + dy + 1)) dy++;

--- a/src/pages/snake.js
+++ b/src/pages/snake.js
@@ -10,6 +10,7 @@ export function mount(container) {
   let rafId = null;
   let lastTime = 0;
   let tickAcc = 0;
+  let prevStarted = false;
   let paused = false;
   let gameOver = false;
   let cleanupControls = null;
@@ -74,6 +75,10 @@ export function mount(container) {
 
     if (!paused && !gameOver) {
       if (state.started) startOverlay.classList.add('hidden');
+      if (state.started && !prevStarted) {
+        prevStarted = true;
+        tickAcc = 0;
+      }
       tickAcc += delta;
       if (tickAcc >= state.speed) {
         tickAcc -= state.speed;

--- a/src/pages/snake.js
+++ b/src/pages/snake.js
@@ -20,6 +20,10 @@ export function mount(container) {
       <div class="game-layout">
         <div class="game-area">
           <canvas id="snake-canvas" width="${CANVAS_SIZE}" height="${CANVAS_SIZE}"></canvas>
+          <div class="start-overlay" id="snake-start">
+            <h2>Snake</h2>
+            <p>Drücke eine Pfeiltaste oder W/A/S/D zum Starten</p>
+          </div>
           <div class="pause-overlay hidden" id="snake-pause">⏸ Pause</div>
           <div class="game-over-overlay hidden" id="snake-over">
             <h2>Game Over</h2>
@@ -44,8 +48,9 @@ export function mount(container) {
       </div>
     </div>`;
 
-  const canvas  = document.getElementById('snake-canvas');
-  const overlay = document.getElementById('snake-over');
+  const canvas       = document.getElementById('snake-canvas');
+  const overlay      = document.getElementById('snake-over');
+  const startOverlay = document.getElementById('snake-start');
   const pauseOverlay = document.getElementById('snake-pause');
 
   function togglePause() {
@@ -68,6 +73,7 @@ export function mount(container) {
     lastTime = timestamp;
 
     if (!paused && !gameOver) {
+      if (state.started) startOverlay.classList.add('hidden');
       tickAcc += delta;
       if (tickAcc >= state.speed) {
         tickAcc -= state.speed;
@@ -87,7 +93,7 @@ export function mount(container) {
     cancelAnimationFrame(rafId);
     rafId = null;
 
-    const duration = Math.max(5, Math.floor((Date.now() - state.startTime) / 1000));
+    const duration = Math.max(5, Math.floor((Date.now() - (state.startTime ?? Date.now())) / 1000));
     overlay.classList.remove('hidden');
     document.getElementById('final-score').textContent = state.score.toLocaleString('de-DE');
 

--- a/src/pages/tetris.js
+++ b/src/pages/tetris.js
@@ -1,4 +1,4 @@
-import { createState, dispatch as gameDispatch, getLevelSpeed } from '../games/tetris/logic.js';
+import { createState, start, dispatch as gameDispatch, getLevelSpeed } from '../games/tetris/logic.js';
 import { render, renderMini, CANVAS_W, CANVAS_H } from '../games/tetris/renderer.js';
 import { bindControls, bindTouchControls } from '../games/tetris/controls.js';
 import { saveScore, getLeaderboard } from '../api/scores.js';
@@ -83,8 +83,9 @@ export function mount(container) {
 
   function dispatchAction(action) {
     if (paused || gameOver) return;
+    if (action === 'hold' && !state.started) return;
     if (!state.started) {
-      state = { ...state, started: true, startTime: Date.now() };
+      state = start(state);
       startOverlay.classList.add('hidden');
     }
     state = gameDispatch(state, action);

--- a/src/pages/tetris.js
+++ b/src/pages/tetris.js
@@ -20,6 +20,10 @@ export function mount(container) {
       <div class="game-layout">
         <div class="game-area">
           <canvas id="tetris-canvas" width="${CANVAS_W}" height="${CANVAS_H}"></canvas>
+          <div class="start-overlay" id="tetris-start">
+            <h2>Tetris</h2>
+            <p>Drücke eine Taste zum Starten</p>
+          </div>
           <div class="pause-overlay hidden" id="tetris-pause">⏸ Pause</div>
           <div class="game-over-overlay hidden" id="tetris-over">
             <h2>Game Over</h2>
@@ -56,10 +60,11 @@ export function mount(container) {
       </div>
     </div>`;
 
-  const canvas    = document.getElementById('tetris-canvas');
-  const nextCanvas = document.getElementById('next-canvas');
-  const holdCanvas = document.getElementById('hold-canvas');
-  const overlay   = document.getElementById('tetris-over');
+  const canvas       = document.getElementById('tetris-canvas');
+  const nextCanvas   = document.getElementById('next-canvas');
+  const holdCanvas   = document.getElementById('hold-canvas');
+  const overlay      = document.getElementById('tetris-over');
+  const startOverlay = document.getElementById('tetris-start');
   const pauseOverlay = document.getElementById('tetris-pause');
 
   function togglePause() {
@@ -78,6 +83,10 @@ export function mount(container) {
 
   function dispatchAction(action) {
     if (paused || gameOver) return;
+    if (!state.started) {
+      state = { ...state, started: true, startTime: Date.now() };
+      startOverlay.classList.add('hidden');
+    }
     state = gameDispatch(state, action);
     render(canvas, state);
     updateStats();
@@ -94,12 +103,14 @@ export function mount(container) {
   function loop(timestamp) {
     if (!paused && !gameOver) {
       const delta = timestamp - lastTime;
-      dropAcc += delta;
-      const speed = getLevelSpeed(state.level);
-      if (dropAcc >= speed) {
-        dropAcc -= speed;
-        state = gameDispatch(state, 'softDrop');
-        if (!state.alive) { endGame(); return; }
+      if (state.started) {
+        dropAcc += delta;
+        const speed = getLevelSpeed(state.level);
+        if (dropAcc >= speed) {
+          dropAcc -= speed;
+          state = gameDispatch(state, 'softDrop');
+          if (!state.alive) { endGame(); return; }
+        }
       }
       render(canvas, state);
       updateStats();
@@ -113,7 +124,7 @@ export function mount(container) {
     cancelAnimationFrame(rafId);
     rafId = null;
 
-    const duration = Math.max(5, Math.floor((Date.now() - state.startTime) / 1000));
+    const duration = Math.max(5, Math.floor((Date.now() - (state.startTime ?? Date.now())) / 1000));
     overlay.classList.remove('hidden');
     document.getElementById('final-score').textContent = state.score.toLocaleString('de-DE');
 


### PR DESCRIPTION
## Summary

- Snake no longer moves on page load; Tetris pieces no longer auto-drop until the player gives their first input. A semi-transparent start overlay communicates this to the player.
- `duration_seconds` is now measured from the moment play actually starts (first key/touch), not from page load, keeping the DB score-plausibility check accurate.
- The `started` / `startTime` flags live purely in game state (no DOM in logic); `start()` in Snake logic is idempotent and called by both keyboard and touch-pad handlers in controls.js.

Closes #6

## Test plan

- [ ] Navigate to Snake: overlay "Drücke eine Pfeiltaste oder W/A/S/D zum Starten" is visible, snake is stationary
- [ ] Press an arrow key / WASD: overlay disappears, snake begins moving immediately
- [ ] Let snake die without pressing any key — game-over overlay appears with Score 0 (edge case: duration falls back to `Math.max(5, …)`)
- [ ] Navigate to Tetris: overlay "Drücke eine Taste zum Starten" is visible, piece sits at top, Score = 0, no auto-drop
- [ ] Press any Tetris key (move/rotate/drop): overlay disappears, auto-drop begins, piece moves normally
- [ ] Restart (Nochmal button) resets to start-gate state on both games
- [ ] Auth modal input fields still do not trigger game controls (existing regression guard)
- [ ] Mobile viewport (≤ 700 px): touch D-pad buttons trigger start and hide overlay correctly
- [ ] `npm run build` exits with code 0, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)