### PR TITLE
feat(leaderboard): loading skeleton, error/retry, 60s cache

### DIFF
--- a/src/pages/snake.js
+++ b/src/pages/snake.js
@@ -3,7 +3,7 @@ import { render, CANVAS_SIZE } from '../games/snake/renderer.js';
 import { bindControls, bindTouchControls } from '../games/snake/controls.js';
 import { saveScore } from '../api/scores.js';
 import { getUser } from '../api/auth.js';
-import { renderLeaderboard } from '../ui/leaderboard.js';
+import { renderLeaderboard, invalidate } from '../ui/leaderboard.js';
 
 export function mount(container) {
   let state = createState();
@@ -98,6 +98,7 @@ export function mount(container) {
       try {
         await saveScore('snake', state.score, duration);
         statusEl.textContent = '✓ Score gespeichert!';
+        invalidate('snake');
         await renderLeaderboard(document.getElementById('leaderboard-area'), 'snake');
       } catch (e) {
         statusEl.textContent = '⚠ ' + e.message;

--- a/src/pages/tetris.js
+++ b/src/pages/tetris.js
@@ -3,7 +3,7 @@ import { render, renderMini, CANVAS_W, CANVAS_H } from '../games/tetris/renderer
 import { bindControls, bindTouchControls } from '../games/tetris/controls.js';
 import { saveScore, getLeaderboard } from '../api/scores.js';
 import { getUser } from '../api/auth.js';
-import { renderLeaderboard } from '../ui/leaderboard.js';
+import { renderLeaderboard, invalidate } from '../ui/leaderboard.js';
 
 export function mount(container) {
   let state = createState();
@@ -124,6 +124,7 @@ export function mount(container) {
       try {
         await saveScore('tetris', state.score, duration);
         statusEl.textContent = '✓ Score gespeichert!';
+        invalidate('tetris');
         await renderLeaderboard(document.getElementById('leaderboard-area'), 'tetris');
       } catch (e) {
         statusEl.textContent = '⚠ ' + e.message;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -248,7 +248,55 @@ a:hover { text-decoration: underline; }
 .lb-table .top-1 td { color: #ffd700; }
 .lb-table .top-2 td { color: #c0c0c0; }
 .lb-table .top-3 td { color: #cd7f32; }
-.lb-empty, .lb-error { color: var(--text-muted); font-size: 0.9rem; padding: 0.5rem 0; }
+.lb-empty { color: var(--text-muted); font-size: 0.9rem; padding: 0.5rem 0; }
+
+/* Skeleton */
+.lb-table--skeleton td { padding: 0.5rem; }
+.skeleton-bar {
+  display: block;
+  height: 0.7rem;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.08);
+  animation: lb-pulse 1.2s ease-in-out infinite;
+}
+.skeleton-bar.--sk-narrow { width: 1.5rem; }
+.skeleton-bar.--sk-medium { width: 3.5rem; }
+.skeleton-bar.--sk-wide   { width: 5rem; }
+
+@keyframes lb-pulse {
+  0%, 100% { opacity: 0.4; }
+  50%       { opacity: 1; }
+}
+
+.lb-status {
+  /* visually hidden but available to screen readers */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Error / Retry */
+.lb-error { display: flex; flex-direction: column; align-items: flex-start; gap: 0.5rem; color: var(--text-muted); font-size: 0.9rem; padding: 0.5rem 0; }
+.lb-retry {
+  padding: 0.25rem 0.75rem;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.lb-retry:hover { color: var(--accent); border-color: var(--accent); }
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-bar { animation: none; opacity: 0.6; }
+}
 
 /* ===== Auth Modal ===== */
 dialog {

--- a/src/ui/leaderboard.js
+++ b/src/ui/leaderboard.js
@@ -1,5 +1,12 @@
 import { getLeaderboard } from '../api/scores.js';
 
+const cache = new Map();
+const TTL_MS = 60_000;
+
+export function invalidate(game) {
+  cache.delete(game);
+}
+
 export async function renderLeaderboard(container, activeGame = 'tetris') {
   container.innerHTML = '';
 
@@ -16,6 +23,7 @@ export async function renderLeaderboard(container, activeGame = 'tetris') {
   ['tetris', 'snake'].forEach(game => {
     const btn = document.createElement('button');
     btn.setAttribute('role', 'tab');
+    btn.setAttribute('type', 'button');
     btn.textContent = game.charAt(0).toUpperCase() + game.slice(1);
     btn.dataset.game = game;
     if (game === activeGame) btn.classList.add('active');
@@ -28,36 +36,114 @@ export async function renderLeaderboard(container, activeGame = 'tetris') {
   section.appendChild(content);
   container.appendChild(section);
 
-  async function loadTable(game) {
-    content.textContent = 'Lade…';
+  function setState(view, payload) {
+    content.innerHTML = '';
+    if (view === 'loading') {
+      renderSkeleton(content);
+    } else if (view === 'error') {
+      renderError(content, payload);
+    } else if (view === 'empty') {
+      const p = document.createElement('p');
+      p.className = 'lb-empty';
+      p.textContent = 'Noch keine Einträge.';
+      content.appendChild(p);
+    } else if (view === 'data') {
+      renderTable(content, payload);
+    }
+  }
+
+  async function loadTable(game, { force = false } = {}) {
+    const entry = cache.get(game);
+    if (!force && entry && (Date.now() - entry.timestamp) < TTL_MS) {
+      setState('data', entry.data);
+      return;
+    }
+
+    setState('loading');
     try {
       const scores = await getLeaderboard(game, 10);
-      renderTable(content, scores);
+      cache.set(game, { data: scores, timestamp: Date.now() });
+      if (scores.length === 0) {
+        setState('empty');
+      } else {
+        setState('data', scores);
+      }
     } catch {
-      content.textContent = 'Fehler beim Laden.';
+      // Errors are not cached so retry always triggers a fresh fetch
+      setState('error', {
+        onRetry: () => loadTable(game, { force: true }),
+      });
     }
   }
 
   tabs.querySelectorAll('[role=tab]').forEach(tab => {
-    tab.addEventListener('click', async () => {
+    tab.addEventListener('click', () => {
       tabs.querySelectorAll('[role=tab]').forEach(t => t.classList.toggle('active', t === tab));
-      await loadTable(tab.dataset.game);
+      loadTable(tab.dataset.game);
     });
   });
 
   await loadTable(activeGame);
 }
 
-function renderTable(container, scores) {
-  container.innerHTML = '';
-  if (!scores.length) {
-    const p = document.createElement('p');
-    p.className = 'lb-empty';
-    p.textContent = 'Noch keine Einträge.';
-    container.appendChild(p);
-    return;
-  }
+function renderSkeleton(container) {
+  // aria-hidden keeps screen readers from reading placeholder content
+  const table = document.createElement('table');
+  table.className = 'lb-table lb-table--skeleton';
+  table.setAttribute('aria-hidden', 'true');
 
+  const thead = document.createElement('thead');
+  const hr = document.createElement('tr');
+  ['#', 'Spieler', 'Punkte', 'Datum'].forEach(h => {
+    const th = document.createElement('th');
+    th.textContent = h;
+    hr.appendChild(th);
+  });
+  thead.appendChild(hr);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  const widths = ['--sk-narrow', '--sk-narrow', '--sk-wide', '--sk-medium'];
+  for (let i = 0; i < 6; i++) {
+    const tr = document.createElement('tr');
+    widths.forEach(w => {
+      const td = document.createElement('td');
+      const span = document.createElement('span');
+      span.className = `skeleton-bar ${w}`;
+      td.appendChild(span);
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  container.appendChild(table);
+
+  const status = document.createElement('p');
+  status.className = 'lb-status';
+  status.setAttribute('role', 'status');
+  status.textContent = 'Lade…';
+  container.appendChild(status);
+}
+
+function renderError(container, { onRetry }) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'lb-error';
+
+  const msg = document.createElement('p');
+  msg.textContent = 'Fehler beim Laden.';
+  wrapper.appendChild(msg);
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'lb-retry';
+  btn.textContent = 'Erneut versuchen';
+  btn.addEventListener('click', onRetry);
+  wrapper.appendChild(btn);
+
+  container.appendChild(wrapper);
+}
+
+function renderTable(container, scores) {
   const medals = ['🥇', '🥈', '🥉'];
   const table = document.createElement('table');
   table.className = 'lb-table';


### PR DESCRIPTION
Closes #9

## Summary

- **Cache (60 s TTL):** Tab switches within the TTL window serve data instantly from a module-scope `Map` without a network round-trip. `invalidate(game)` is called by the page immediately after a successful `saveScore` so the new score is always fetched fresh.
- **Loading skeleton:** While a fetch is in-flight, a `<table aria-hidden="true">` with 6 shimmer rows (CSS `@keyframes lb-pulse`) replaces the content area. A visually-hidden `<p role="status">Lade…</p>` covers screen readers. `prefers-reduced-motion` stops the animation.
- **Error / Retry:** On network failure the skeleton is replaced by "Fehler beim Laden." and a `<button type="button" class="lb-retry">Erneut versuchen</button>`. Errors are never cached, so retry always triggers a fresh fetch.

## Test plan

- [ ] Open Tetris or Snake in-game leaderboard; watch Network tab: initial load fires a request, subsequent tab switches within 60 s fire **no** further requests.
- [ ] Wait > 60 s, switch tab → request fires again and cache refreshes.
- [ ] DevTools → Network: set **Offline**; switch leaderboard tab → skeleton appears briefly, then error message + retry button appear.
- [ ] Click "Erneut versuchen" while still offline → skeleton again, then error (no stale cached error path).
- [ ] Go back online, click retry → data loads correctly.
- [ ] DevTools → Rendering → Emulate CSS media feature `prefers-reduced-motion: reduce` → skeleton bars are static (opacity 0.6, no animation).
- [ ] Mobile viewport (≤ 700 px): skeleton and error views are legible and do not cause horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)