### PR TITLE
Add keyboard control hints to game sidebars

### DIFF
--- a/src/pages/snake.js
+++ b/src/pages/snake.js
@@ -55,6 +55,14 @@ export function mount(container) {
               <div class="stat-label">Länge</div>
               <div class="stat-value" id="length-val">3</div>
             </div>
+            <div class="stat-box controls-help">
+              <div class="stat-label">Steuerung</div>
+              <dl class="controls-list">
+                <dt><kbd>←</kbd> <kbd>↑</kbd> <kbd>→</kbd> <kbd>↓</kbd></dt><dd>Richtung</dd>
+                <dt><kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd></dt><dd>Richtung</dd>
+                <dt><kbd>P</kbd> <kbd>Esc</kbd></dt><dd>Pause</dd>
+              </dl>
+            </div>
           </div>
           <div id="leaderboard-area"></div>
         </aside>

--- a/src/pages/tetris.js
+++ b/src/pages/tetris.js
@@ -73,6 +73,17 @@ export function mount(container) {
               <div class="stat-label">Hold (C)</div>
               <canvas id="hold-canvas" width="96" height="96"></canvas>
             </div>
+            <div class="stat-box controls-help">
+              <div class="stat-label">Steuerung</div>
+              <dl class="controls-list">
+                <dt><kbd>←</kbd> <kbd>→</kbd></dt><dd>Bewegen</dd>
+                <dt><kbd>↓</kbd> <kbd>S</kbd></dt><dd>Soft-Drop</dd>
+                <dt><kbd>Leertaste</kbd></dt><dd>Hard-Drop</dd>
+                <dt><kbd>↑</kbd> <kbd>Z</kbd> <kbd>W</kbd></dt><dd>Drehen</dd>
+                <dt><kbd>C</kbd> <kbd>Shift</kbd></dt><dd>Hold</dd>
+                <dt><kbd>P</kbd> <kbd>Esc</kbd></dt><dd>Pause</dd>
+              </dl>
+            </div>
           </div>
           <div id="leaderboard-area"></div>
         </aside>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -242,6 +242,34 @@ a:hover { text-decoration: underline; }
 .stat-value { font-size: 1.5rem; font-weight: 700; font-variant-numeric: tabular-nums; }
 .stat-box canvas { display: block; margin-top: 0.5rem; }
 
+/* ===== Controls Help ===== */
+.controls-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 0.75rem;
+  margin: 0;
+  font-size: 0.8rem;
+  list-style: none;
+}
+.controls-list dt {
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+}
+.controls-list dd {
+  color: var(--text-muted);
+  margin: 0;
+}
+.controls-list kbd {
+  background: var(--surface2);
+  border: 1px solid rgba(255,255,255,0.15);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-family: monospace;
+  line-height: 1;
+}
+
 /* ===== Leaderboard ===== */
 .leaderboard { background: var(--surface); border: 1px solid rgba(255,255,255,0.08); border-radius: var(--radius); padding: 1rem; }
 .leaderboard h3 { font-size: 1rem; margin-bottom: 0.75rem; }
@@ -492,6 +520,7 @@ dialog::backdrop {
   }
 
   .game-cards { grid-template-columns: 1fr; }
+  .controls-help { display: none; }
   #nav { padding: 0 1rem; }
 }
 


### PR DESCRIPTION
Closes #5

## Summary

- Adds a `Steuerung` stat-box with `<kbd>`-tagged key bindings to the Tetris and Snake sidebars, so first-time players immediately know all controls without trial and error.
- Custom CSS styles `<kbd>` elements to match the dark-theme surface (monospace, rounded border, `var(--surface2)` background) — no browser-default styling.
- Hides the box on mobile viewports (≤ 700 px) via the existing media query, because touch buttons there are already self-explanatory.

> **Note on Pause bindings (P / Esc):** These are listed in both hint boxes but the actual pause implementation lives in `feat/pause-function` (PR #12), which is not yet merged into `main`. If #12 merges first the hints are immediately functional; if this PR merges first they serve as a forward-looking indicator that pause is coming.

## Test plan

- [ ] Navigate to `#/tetris` — "Steuerung" box appears in the right sidebar below "Hold (C)", above the leaderboard.
- [ ] All keys are rendered as styled `<kbd>` chips (dark pill with border, monospace), not plain text.
- [ ] Navigate to `#/snake` — same box appears below "Länge".
- [ ] Open DevTools → toggle mobile viewport (e.g. 375 × 667) — "Steuerung" box disappears; touch D-pad visible.
- [ ] Switch back to desktop — box reappears; leaderboard layout unaffected.
- [ ] `npm run build` completes without errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)