### PR TITLE
Fix mobile layout: score strip, fixed D-pad, canvas sizing

### DIFF
--- a/src/pages/snake.js
+++ b/src/pages/snake.js
@@ -18,6 +18,17 @@ export function mount(container) {
 
   container.innerHTML = `
     <div class="game-page">
+      <!-- Mobile score strip (sticky, above canvas) -->
+      <div class="sidebar-stats--strip">
+        <div class="stat-box">
+          <div class="stat-label">Score</div>
+          <div class="stat-value" id="score-val-strip">0</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-label">Länge</div>
+          <div class="stat-value" id="length-val-strip">3</div>
+        </div>
+      </div>
       <div class="game-layout">
         <div class="game-area">
           <canvas id="snake-canvas" width="${CANVAS_SIZE}" height="${CANVAS_SIZE}"></canvas>
@@ -34,6 +45,7 @@ export function mount(container) {
           </div>
         </div>
         <aside class="game-sidebar">
+          <!-- Desktop sidebar stats (Score/Länge) -->
           <div class="sidebar-stats">
             <div class="stat-box">
               <div class="stat-label">Score</div>
@@ -67,7 +79,7 @@ export function mount(container) {
   }
 
   cleanupControls = bindControls({ pause: togglePause }, getState, setState);
-  cleanupTouch = bindTouchControls(container.querySelector('.game-area'), getState, setState);
+  cleanupTouch = bindTouchControls(container.querySelector('.game-page'), getState, setState);
 
   function loop(timestamp) {
     const delta = timestamp - lastTime;
@@ -83,8 +95,12 @@ export function mount(container) {
       if (tickAcc >= state.speed) {
         tickAcc -= state.speed;
         state = tick(state);
-        document.getElementById('score-val').textContent = state.score.toLocaleString('de-DE');
-        document.getElementById('length-val').textContent = state.snake.length;
+        const score = state.score.toLocaleString('de-DE');
+        const length = state.snake.length;
+        document.getElementById('score-val').textContent = score;
+        document.getElementById('length-val').textContent = length;
+        document.getElementById('score-val-strip').textContent = score;
+        document.getElementById('length-val-strip').textContent = length;
         if (!state.alive) { endGame(); return; }
       }
       render(canvas, state);

--- a/src/pages/tetris.js
+++ b/src/pages/tetris.js
@@ -17,6 +17,21 @@ export function mount(container) {
 
   container.innerHTML = `
     <div class="game-page">
+      <!-- Mobile score strip (sticky, above canvas) -->
+      <div class="sidebar-stats--strip">
+        <div class="stat-box">
+          <div class="stat-label">Score</div>
+          <div class="stat-value" id="score-val-strip">0</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-label">Level</div>
+          <div class="stat-value" id="level-val-strip">1</div>
+        </div>
+        <div class="stat-box">
+          <div class="stat-label">Lines</div>
+          <div class="stat-value" id="lines-val-strip">0</div>
+        </div>
+      </div>
       <div class="game-layout">
         <div class="game-area">
           <canvas id="tetris-canvas" width="${CANVAS_W}" height="${CANVAS_H}"></canvas>
@@ -33,6 +48,7 @@ export function mount(container) {
           </div>
         </div>
         <aside class="game-sidebar">
+          <!-- Desktop sidebar stats (Score/Level/Lines) -->
           <div class="sidebar-stats">
             <div class="stat-box">
               <div class="stat-label">Score</div>
@@ -46,6 +62,9 @@ export function mount(container) {
               <div class="stat-label">Lines</div>
               <div class="stat-value" id="lines-val">0</div>
             </div>
+          </div>
+          <!-- Next + Hold: visible on desktop in sidebar, scrollable below fold on mobile -->
+          <div class="sidebar-extras">
             <div class="stat-box">
               <div class="stat-label">Nächstes</div>
               <canvas id="next-canvas" width="96" height="96"></canvas>
@@ -74,9 +93,15 @@ export function mount(container) {
   }
 
   function updateStats() {
-    document.getElementById('score-val').textContent = state.score.toLocaleString('de-DE');
-    document.getElementById('level-val').textContent = state.level + 1;
-    document.getElementById('lines-val').textContent = state.lines;
+    const score = state.score.toLocaleString('de-DE');
+    const level = state.level + 1;
+    const lines = state.lines;
+    document.getElementById('score-val').textContent = score;
+    document.getElementById('level-val').textContent = level;
+    document.getElementById('lines-val').textContent = lines;
+    document.getElementById('score-val-strip').textContent = score;
+    document.getElementById('level-val-strip').textContent = level;
+    document.getElementById('lines-val-strip').textContent = lines;
     renderMini(nextCanvas, state.next);
     renderMini(holdCanvas, state.held);
   }
@@ -99,7 +124,7 @@ export function mount(container) {
     () => state,
     dispatchAction
   );
-  cleanupTouch = bindTouchControls(container.querySelector('.game-area'), dispatchAction);
+  cleanupTouch = bindTouchControls(container.querySelector('.game-page'), dispatchAction);
 
   function loop(timestamp) {
     if (!paused && !gameOver) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,16 +1,20 @@
 /* ===== CSS Custom Properties ===== */
 :root {
-  --bg:          #0a0a0f;
-  --surface:     #1a1a2e;
-  --surface2:    #22223b;
-  --accent:      #7f5af0;
-  --accent2:     #2cb67d;
-  --text:        #fffffe;
-  --text-muted:  #94a1b2;
-  --danger:      #e53170;
-  --success:     #2cb67d;
-  --radius:      8px;
-  --nav-h:       56px;
+  --bg:            #0a0a0f;
+  --surface:       #1a1a2e;
+  --surface2:      #22223b;
+  --accent:        #7f5af0;
+  --accent2:       #2cb67d;
+  --text:          #fffffe;
+  --text-muted:    #94a1b2;
+  --danger:        #e53170;
+  --success:       #2cb67d;
+  --radius:        8px;
+  --nav-h:         56px;
+  --score-strip-h: 48px;
+  --dpad-h:        208px;
+  --safe-bottom:   env(safe-area-inset-bottom, 0px);
+  --dpad-btn-size: 56px;
 }
 
 /* ===== Reset & Base ===== */
@@ -150,6 +154,11 @@ a:hover { text-decoration: underline; }
   border-radius: 4px;
 }
 
+/* Score strip — visible only on mobile (hidden on desktop via media query) */
+.sidebar-stats--strip {
+  display: none;
+}
+
 /* ===== Game Over Overlay ===== */
 .game-over-overlay {
   position: absolute;
@@ -213,6 +222,13 @@ a:hover { text-decoration: underline; }
 .sidebar-stats {
   display: flex;
   flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Next + Hold in a two-column grid inside the sidebar */
+.sidebar-extras {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 0.75rem;
 }
 
@@ -370,12 +386,11 @@ dialog::backdrop {
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
-  margin-top: 1rem;
 }
 .dpad-row { display: flex; gap: 0.5rem; }
 .dpad-btn {
-  width: 56px;
-  height: 56px;
+  width: var(--dpad-btn-size);
+  height: var(--dpad-btn-size);
   background: var(--surface2);
   border: 1px solid rgba(255,255,255,0.15);
   border-radius: var(--radius);
@@ -413,11 +428,118 @@ dialog::backdrop {
 
 /* ===== Responsive ===== */
 @media (max-width: 700px) {
+  /* Score strip replaces sidebar stats on mobile */
+  .sidebar-stats--strip {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    height: var(--score-strip-h);
+    padding: 0 0.75rem;
+    background: var(--surface);
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+    position: sticky;
+    top: var(--nav-h);
+    z-index: 80;
+  }
+  .sidebar-stats--strip .stat-box {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.3rem 0.6rem;
+    border: none;
+    background: transparent;
+  }
+  .sidebar-stats--strip .stat-label {
+    font-size: 0.65rem;
+  }
+  .sidebar-stats--strip .stat-value {
+    font-size: 1.1rem;
+  }
+
+  /* Canvas sizing: fill available space between strip and fixed D-pad */
+  .game-area canvas {
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: calc(100dvh - var(--nav-h) - var(--score-strip-h) - var(--dpad-h) - var(--safe-bottom) - 16px);
+  }
+
+  /* Game layout stacks vertically on mobile */
   .game-layout { flex-direction: column; align-items: center; }
   .game-sidebar { max-width: 100%; width: 100%; }
+
+  /* Hide desktop sidebar stats; sidebar-extras (Next/Hold) scroll below fold */
+  .game-sidebar .sidebar-stats { display: none; }
+
+  /* Enough bottom padding so content doesn't hide under fixed D-pad */
+  .game-page {
+    padding-bottom: calc(var(--dpad-h) + var(--safe-bottom));
+  }
+
+  /* Fixed D-pad at bottom */
+  .touch-controls {
+    display: flex;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0.5rem 0.5rem calc(0.5rem + var(--safe-bottom));
+    background: var(--bg);
+    z-index: 90;
+    border-top: 1px solid rgba(255,255,255,0.08);
+  }
+
   .game-cards { grid-template-columns: 1fr; }
-  .touch-controls { display: flex; }
   #nav { padding: 0 1rem; }
+}
+
+/* Landscape: canvas left, D-pad right; leaderboard hidden during play */
+@media (max-width: 900px) and (orientation: landscape) and (max-height: 500px) {
+  .game-page {
+    padding-bottom: 0;
+  }
+  .game-layout {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .game-area {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .game-area canvas {
+    max-height: calc(100dvh - var(--nav-h) - 16px);
+    max-width: 100%;
+    width: auto;
+    height: auto;
+  }
+  /* D-pad fixed to the right side in landscape */
+  .touch-controls {
+    display: flex;
+    position: fixed;
+    right: 0;
+    top: var(--nav-h);
+    left: auto;
+    bottom: 0;
+    width: calc(var(--dpad-h) + 1rem);
+    padding: 0.5rem;
+    flex-direction: column;
+    justify-content: center;
+    background: var(--bg);
+    border-left: 1px solid rgba(255,255,255,0.08);
+    border-top: none;
+    z-index: 90;
+  }
+  /* Hide leaderboard + extras during play in landscape */
+  .game-sidebar {
+    display: none;
+  }
+  /* Hide strip header in landscape too — no space */
+  .sidebar-stats--strip {
+    display: none;
+  }
 }
 
 @media (max-width: 420px) {


### PR DESCRIPTION
Closes #4

## Summary

- **Score always visible on mobile**: A sticky strip (`sidebar-stats--strip`) above the canvas shows Score/Level/Lines (Tetris) and Score/Länge (Snake), replacing the sidebar stats that were previously hidden below the fold.
- **D-pad fixed to viewport bottom**: `.touch-controls` is now `position: fixed; bottom: 0` with `env(safe-area-inset-bottom)` padding, so buttons are always reachable and never obscured by the canvas.
- **Canvas fills available space precisely**: `max-height: calc(100dvh - --nav-h - --score-strip-h - --dpad-h - --safe-bottom - 16px)` ensures the game area fits between the strip and the D-pad with no scroll needed.
- **Landscape two-column layout**: `@media (max-width: 900px) and (orientation: landscape) and (max-height: 500px)` places canvas left and D-pad fixed on the right; sidebar/leaderboard hidden to conserve space.

## Test plan

- [ ] **Desktop (>700px)**: Sidebar appears to the right of the canvas with Score/Level/Lines and Next/Hold boxes. No score strip visible. No D-pad.
- [ ] **Portrait mobile ≤700px (e.g. 375×667)**: Score strip sticky below nav, canvas fills remaining space, D-pad fixed at bottom. Leaderboard/Hold/Next scrollable below fold. Restart button after game-over works.
- [ ] **Landscape mobile (e.g. 650×350)**: Canvas on the left, D-pad fixed on the right. Strip hidden. Sidebar hidden. Game controls still work.
- [ ] **Safe-area devices (iPhone with home indicator)**: D-pad has extra bottom padding, content not clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)