### PR TITLE
Fix auth-modal: centering, a11y, pattern validation, autocomplete, mode reset, forgot-password

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <body>
     <nav id="nav"></nav>
     <main id="app"></main>
-    <dialog id="auth-modal"></dialog>
+    <dialog id="auth-modal" aria-labelledby="auth-modal-title" aria-modal="true"></dialog>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -5,6 +5,9 @@ const ERROR_MAP = {
   'User already registered': 'Diese E-Mail ist bereits registriert.',
   'Email not confirmed': 'Bitte bestätige zuerst deine E-Mail.',
   'Password should be at least 6 characters': 'Passwort muss mindestens 6 Zeichen haben.',
+  'Email rate limit exceeded': 'Zu viele Versuche. Bitte später erneut probieren.',
+  'Unable to validate email address: invalid format': 'Ungültige E-Mail-Adresse.',
+  'For security purposes, you can only request this once every 60 seconds': 'Aus Sicherheitsgründen nur einmal pro Minute möglich. Bitte warten.',
 };
 
 function mapError(msg) {
@@ -44,4 +47,11 @@ export async function getUser() {
 export function onAuthChange(cb) {
   const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => cb(session));
   return () => subscription.unsubscribe();
+}
+
+export async function resetPassword(email) {
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: window.location.origin + import.meta.env.BASE_URL,
+  });
+  if (error) throw new Error(mapError(error.message));
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -221,6 +221,12 @@ dialog {
   background: transparent;
   border: none;
   padding: 0;
+  /* Canonical centering for <dialog> — replaces browser default top-left placement */
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  width: fit-content;
+  height: fit-content;
   max-width: 100vw;
   max-height: 100vh;
 }
@@ -237,6 +243,19 @@ dialog::backdrop {
   padding: 2rem;
   width: min(400px, 90vw);
 }
+
+.modal-box h2 {
+  margin-top: 0;
+  font-size: 1.3rem;
+  color: var(--text);
+}
+
+.auth-forgot {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-decoration: underline;
+}
+.auth-forgot:hover { color: var(--accent); }
 
 .modal-close {
   position: absolute;

--- a/src/ui/auth-modal.js
+++ b/src/ui/auth-modal.js
@@ -59,7 +59,7 @@ export function initAuthModal() {
       submitBtn.textContent = 'Anmelden';
       nameLabel.classList.add('hidden');
       nameInput.removeAttribute('required');
-      passwordLabel.hidden = false;
+      passwordLabel.classList.remove('hidden');
       passwordInput.required = true;
       passwordInput.setAttribute('autocomplete', 'current-password');
       forgotLink.hidden = false;
@@ -69,7 +69,7 @@ export function initAuthModal() {
       submitBtn.textContent = 'Registrieren';
       nameLabel.classList.remove('hidden');
       nameInput.required = true;
-      passwordLabel.hidden = false;
+      passwordLabel.classList.remove('hidden');
       passwordInput.required = true;
       passwordInput.setAttribute('autocomplete', 'new-password');
       forgotLink.hidden = true;
@@ -79,7 +79,7 @@ export function initAuthModal() {
       submitBtn.textContent = 'Reset-Link senden';
       nameLabel.classList.add('hidden');
       nameInput.removeAttribute('required');
-      passwordLabel.hidden = true;
+      passwordLabel.classList.add('hidden');
       passwordInput.required = false;
       passwordInput.setAttribute('autocomplete', 'new-password');
       forgotLink.hidden = true;

--- a/src/ui/auth-modal.js
+++ b/src/ui/auth-modal.js
@@ -1,14 +1,15 @@
-import { signIn, signUp } from '../api/auth.js';
+import { signIn, signUp, resetPassword } from '../api/auth.js';
 
 let modal = null;
 
 export function initAuthModal() {
-  if (modal) return { open: () => modal.showModal() };
+  if (modal) return { open: openModal };
 
   modal = document.getElementById('auth-modal');
   modal.innerHTML = `
     <div class="modal-box">
       <button class="modal-close" aria-label="Schließen">✕</button>
+      <h2 id="auth-modal-title">Anmelden</h2>
       <div class="modal-tabs" role="tablist">
         <button class="tab active" role="tab" data-tab="login">Anmelden</button>
         <button class="tab" role="tab" data-tab="register">Registrieren</button>
@@ -19,32 +20,87 @@ export function initAuthModal() {
         </label>
         <label id="name-label" class="hidden">Anzeigename
           <input type="text" name="displayName" minlength="3" maxlength="30"
+                 pattern="[A-Za-z0-9_\\-]{3,30}"
+                 title="3–30 Zeichen, nur Buchstaben, Zahlen, _ und -"
                  placeholder="3-30 Zeichen, Buchstaben/Zahlen/_/-"
                  autocomplete="username" />
         </label>
-        <label>Passwort
+        <label id="password-label">Passwort
           <input type="password" name="password" required minlength="6"
                  autocomplete="current-password" />
         </label>
         <div id="auth-msg" role="alert" class="auth-msg" hidden></div>
         <button type="submit" class="btn-primary">Anmelden</button>
+        <button type="button" class="link-btn auth-forgot" data-tab="forgot">Passwort vergessen?</button>
+        <button type="button" class="link-btn auth-back" hidden>Zurück zum Login</button>
       </form>
     </div>`;
 
   let mode = 'login';
 
+  function setMode(next) {
+    mode = next;
+
+    const title        = modal.querySelector('#auth-modal-title');
+    const tabs         = modal.querySelectorAll('.tab');
+    const nameLabel    = modal.querySelector('#name-label');
+    const nameInput    = nameLabel.querySelector('input');
+    const passwordLabel = modal.querySelector('#password-label');
+    const passwordInput = passwordLabel.querySelector('input');
+    const submitBtn    = modal.querySelector('[type=submit]');
+    const forgotLink   = modal.querySelector('.auth-forgot');
+    const backLink     = modal.querySelector('.auth-back');
+
+    // Tab highlight — forgot is not a visible tab so no tab stays active in that mode
+    tabs.forEach(t => t.classList.toggle('active', t.dataset.tab === next));
+
+    if (next === 'login') {
+      title.textContent = 'Anmelden';
+      submitBtn.textContent = 'Anmelden';
+      nameLabel.classList.add('hidden');
+      nameInput.removeAttribute('required');
+      passwordLabel.hidden = false;
+      passwordInput.required = true;
+      passwordInput.setAttribute('autocomplete', 'current-password');
+      forgotLink.hidden = false;
+      backLink.hidden = true;
+    } else if (next === 'register') {
+      title.textContent = 'Registrieren';
+      submitBtn.textContent = 'Registrieren';
+      nameLabel.classList.remove('hidden');
+      nameInput.required = true;
+      passwordLabel.hidden = false;
+      passwordInput.required = true;
+      passwordInput.setAttribute('autocomplete', 'new-password');
+      forgotLink.hidden = true;
+      backLink.hidden = true;
+    } else if (next === 'forgot') {
+      title.textContent = 'Passwort zurücksetzen';
+      submitBtn.textContent = 'Reset-Link senden';
+      nameLabel.classList.add('hidden');
+      nameInput.removeAttribute('required');
+      passwordLabel.hidden = true;
+      passwordInput.required = false;
+      passwordInput.setAttribute('autocomplete', 'new-password');
+      forgotLink.hidden = true;
+      backLink.hidden = false;
+    }
+
+    clearMsg();
+  }
+
   modal.querySelectorAll('.tab').forEach(tab => {
-    tab.addEventListener('click', () => {
-      mode = tab.dataset.tab;
-      modal.querySelectorAll('.tab').forEach(t => t.classList.toggle('active', t === tab));
-      modal.querySelector('[type=submit]').textContent = mode === 'login' ? 'Anmelden' : 'Registrieren';
-      modal.querySelector('#name-label').classList.toggle('hidden', mode === 'login');
-      clearMsg();
-    });
+    tab.addEventListener('click', () => setMode(tab.dataset.tab));
   });
+
+  modal.querySelector('.auth-forgot').addEventListener('click', () => setMode('forgot'));
+  modal.querySelector('.auth-back').addEventListener('click', () => setMode('login'));
 
   modal.querySelector('.modal-close').addEventListener('click', () => modal.close());
   modal.addEventListener('click', e => { if (e.target === modal) modal.close(); });
+
+  // Reset to login mode whenever the dialog is closed
+  modal.addEventListener('close', () => setMode('login'));
 
   modal.querySelector('#auth-form').addEventListener('submit', async e => {
     e.preventDefault();
@@ -62,16 +118,25 @@ export function initAuthModal() {
       if (mode === 'login') {
         await signIn(email, password);
         modal.close();
-      } else {
+      } else if (mode === 'register') {
         await signUp(email, password, name || email.split('@')[0]);
         showMsg('Erfolgreich registriert! Du bist jetzt eingeloggt.', 'success');
         setTimeout(() => modal.close(), 1500);
+      } else if (mode === 'forgot') {
+        await resetPassword(email);
+        showMsg('Falls die Adresse existiert, wurde ein Reset-Link gesendet.', 'success');
+        e.target.querySelector('[name=email]').value = '';
+        // Leave modal open — user can close manually
+        btn.disabled = false;
+        btn.textContent = 'Reset-Link senden';
+        return;
       }
     } catch (err) {
       showMsg(err.message, 'error');
     } finally {
       btn.disabled = false;
-      btn.textContent = mode === 'login' ? 'Anmelden' : 'Registrieren';
+      const labels = { login: 'Anmelden', register: 'Registrieren', forgot: 'Reset-Link senden' };
+      btn.textContent = labels[mode];
     }
   });
 
@@ -86,5 +151,13 @@ export function initAuthModal() {
     el.hidden = true;
   }
 
-  return { open: () => modal.showModal() };
+  function openModal() {
+    modal.showModal();
+    // Auto-focus the email field after the dialog is painted — native <dialog> handles focus trap
+    requestAnimationFrame(() => {
+      modal.querySelector('input[name="email"]').focus();
+    });
+  }
+
+  return { open: openModal };
 }

--- a/src/ui/auth-modal.js
+++ b/src/ui/auth-modal.js
@@ -99,8 +99,14 @@ export function initAuthModal() {
   modal.querySelector('.modal-close').addEventListener('click', () => modal.close());
   modal.addEventListener('click', e => { if (e.target === modal) modal.close(); });
 
-  // Reset to login mode whenever the dialog is closed
-  modal.addEventListener('close', () => setMode('login'));
+  // Reset to login mode and clear sensitive fields whenever the dialog is closed.
+  // Prevents a previous user's password from being visible when the modal is reopened
+  // on a shared device. Email is intentionally kept for UX (accidental close recovery).
+  modal.addEventListener('close', () => {
+    setMode('login');
+    modal.querySelector('input[name="password"]').value = '';
+    modal.querySelector('input[name="displayName"]').value = '';
+  });
 
   modal.querySelector('#auth-form').addEventListener('submit', async e => {
     e.preventDefault();


### PR DESCRIPTION
Closes #8

## Summary

- **Centering fixed**: `<dialog>` now uses `position: fixed; inset: 0; margin: auto` — the canonical cross-browser approach; previously appeared top-left.
- **A11y**: Added `aria-modal="true"` and `aria-labelledby="auth-modal-title"` to `<dialog>`; auto-focus on email input via `requestAnimationFrame` after `showModal()`; native `<dialog>` focus-trap used, no custom implementation needed.
- **Pattern validation**: Display-name input gains `pattern="[A-Za-z0-9_\-]{3,30}"` and a descriptive `title`; `required` attribute is toggled — only present in register mode — so HTML5 validation fires before the DB ever sees the value.
- **autocomplete toggle**: Centralized `setMode()` function switches password field between `current-password` (login) and `new-password` (register/forgot) so password managers behave correctly.
- **Mode reset on close**: `modal.addEventListener('close', () => setMode('login'))` ensures re-opening always starts in login mode.
- **Forgot-password flow**: New `forgot` sub-mode (entered via link, not a visible tab) hides the password field and calls `resetPassword()` from `src/api/auth.js`; success shows a neutral confirmation message without auto-close; three new Supabase error messages added to `ERROR_MAP`.

## Test Plan

- [ ] Open modal — appears centered on both desktop and mobile (375 x 667 px)
- [ ] Email input is auto-focused on open
- [ ] Switch to Register tab — display-name field appears, `autocomplete="new-password"` visible in DevTools
- [ ] Enter "Max Mustermann" in display-name — browser pattern validation fires before submit
- [ ] Close and re-open modal — mode is Login, not Register
- [ ] Click "Passwort vergessen?" — password field disappears, submit label becomes "Reset-Link senden"
- [ ] Click "Zurück zum Login" — password field returns
- [ ] While modal is open: press W / A / S / D / P / Esc — game controls are NOT triggered (regression from e9100e6)
- [ ] On mobile viewport: modal fits screen without horizontal overflow

## Notes

The `#/reset` landing page that handles the Supabase password-reset redirect URL is **out of scope** here and must be tracked as a follow-up issue. Without that page the reset link will land on the home page after the OAuth redirect.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)