### PR TITLE
Dino-Evo Phase 1b: Migration 004_dinos.sql + Vorlagen-Updates (#26)

### DIFF
--- a/supabase/migrations/001_schema.sql
+++ b/supabase/migrations/001_schema.sql
@@ -1,5 +1,5 @@
 -- Game type enum
-CREATE TYPE public.game_type AS ENUM ('tetris', 'snake');
+CREATE TYPE public.game_type AS ENUM ('tetris', 'snake', 'dinos_realtime', 'dinos_turn');
 
 -- User profiles (linked to auth.users)
 CREATE TABLE public.profiles (
@@ -18,8 +18,10 @@ CREATE TABLE public.scores (
     score            INTEGER NOT NULL CHECK (score >= 0),
     duration_seconds INTEGER NOT NULL CHECK (duration_seconds >= 5 AND duration_seconds <= 7200),
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT tetris_score_limit CHECK (game <> 'tetris' OR score <= 10000000),
-    CONSTRAINT snake_score_limit  CHECK (game <> 'snake'  OR score <= 100000)
+    CONSTRAINT tetris_score_limit          CHECK (game <> 'tetris'         OR score <= 10000000),
+    CONSTRAINT snake_score_limit           CHECK (game <> 'snake'          OR score <= 100000),
+    CONSTRAINT dinos_realtime_score_limit  CHECK (game <> 'dinos_realtime' OR score <= 200),
+    CONSTRAINT dinos_turn_score_limit      CHECK (game <> 'dinos_turn'     OR score <= 5000)
 );
 
 CREATE INDEX idx_scores_game_score      ON public.scores(game, score DESC);

--- a/supabase/migrations/002_rls.sql
+++ b/supabase/migrations/002_rls.sql
@@ -33,10 +33,14 @@ CREATE POLICY "scores: insert own"
     ON public.scores FOR INSERT WITH CHECK (
         auth.uid() IS NOT NULL
         -- Score limits per game
-        AND (game <> 'tetris' OR score <= 10000000)
-        AND (game <> 'snake'  OR score <= 100000)
-        -- Score/time plausibility
+        AND (game <> 'tetris'          OR score <= 10000000)
+        AND (game <> 'snake'           OR score <= 100000)
+        AND (game <> 'dinos_realtime'  OR score <= 200)
+        AND (game <> 'dinos_turn'      OR score <= 5000)
+        -- Score/time plausibility (global)
         AND (score::float / duration_seconds) <= 100000
+        -- dinos_realtime: max 0.05 Generationen/Sekunde (sehr langsamer Prozess)
+        AND (game <> 'dinos_realtime' OR (score::float / duration_seconds) <= 0.05)
         -- Rate limiting
         AND public.count_recent_scores(auth.uid(), 3600) < 10
         AND public.count_recent_scores(auth.uid(), 60)   < 2

--- a/supabase/migrations/004_dinos.sql
+++ b/supabase/migrations/004_dinos.sql
@@ -1,0 +1,57 @@
+-- Migration 004: Dino-Evo – ENUM-Erweiterung + Score-Caps + RLS-Policy-Update
+--
+-- WICHTIG – Ausführungsreihenfolge im Supabase-SQL-Editor:
+--
+--   Section A muss SEPARAT und ZUERST ausgeführt werden (vor Section B).
+--   Grund: ALTER TYPE … ADD VALUE darf in PostgreSQL nicht innerhalb einer
+--   Transaktion laufen (PG-Constraint seit PG 12). Supabase wrapped jede
+--   SQL-Editor-Ausführung implizit – daher Section A als eigener Run.
+--
+--   Section B danach als separater Run ausführen. DROP POLICY + CREATE POLICY
+--   liegen in einer expliziten Transaktion, damit kein Default-Deny-Fenster
+--   zwischen DROP und CREATE entsteht (prod-Inserts würden sonst kurz blockieren).
+
+
+-- ============================================================
+-- Section A: ENUM erweitern (außerhalb Transaktion ausführen)
+-- ============================================================
+
+ALTER TYPE public.game_type ADD VALUE IF NOT EXISTS 'dinos_realtime';
+ALTER TYPE public.game_type ADD VALUE IF NOT EXISTS 'dinos_turn';
+
+
+-- ============================================================
+-- Section B: Constraints + Policy (als eigenen Run ausführen)
+-- ============================================================
+
+BEGIN;
+
+-- Score-Caps für die zwei neuen Spielmodi
+ALTER TABLE public.scores
+    ADD CONSTRAINT dinos_realtime_score_limit
+        CHECK (game <> 'dinos_realtime' OR score <= 200),
+    ADD CONSTRAINT dinos_turn_score_limit
+        CHECK (game <> 'dinos_turn'     OR score <= 5000);
+
+-- Insert-Policy neu erstellen, um die neuen Caps + dinos_realtime-Plausibilität
+-- abzudecken. DROP + CREATE in einer Transaktion verhindert das Default-Deny-Fenster.
+DROP POLICY IF EXISTS "scores: insert own" ON public.scores;
+
+CREATE POLICY "scores: insert own"
+    ON public.scores FOR INSERT WITH CHECK (
+        auth.uid() IS NOT NULL
+        -- Score limits per game
+        AND (game <> 'tetris'          OR score <= 10000000)
+        AND (game <> 'snake'           OR score <= 100000)
+        AND (game <> 'dinos_realtime'  OR score <= 200)
+        AND (game <> 'dinos_turn'      OR score <= 5000)
+        -- Score/time plausibility (global)
+        AND (score::float / duration_seconds) <= 100000
+        -- dinos_realtime: max 0.05 Generationen/Sekunde (sehr langsamer Prozess)
+        AND (game <> 'dinos_realtime' OR (score::float / duration_seconds) <= 0.05)
+        -- Rate limiting
+        AND public.count_recent_scores(auth.uid(), 3600) < 10
+        AND public.count_recent_scores(auth.uid(), 60)   < 2
+    );
+
+COMMIT;


### PR DESCRIPTION
@
## Summary

Phase 1b der Dino-Evo-Implementierung (Issue #26): DB-Migration für die zwei neuen Game-Modes `dinos_realtime` und `dinos_turn`. Score-Caps und Plausibilitäts-Klausel folgen dem [Phase-0-Brief](https://github.com/kangsdoteu/claude-game/issues/26#issuecomment-4365984511); Migration-Struktur folgt dem [Architektur-Spec-Review (Sektion E)](https://github.com/kangsdoteu/claude-game/issues/26#issuecomment-4366006132).

### Geänderte Dateien

- **`supabase/migrations/004_dinos.sql`** (neu) — Section A (`ALTER TYPE … ADD VALUE`, außerhalb Transaktion) + Section B (`BEGIN; …; COMMIT;` für CHECK-Constraints und Policy-Replace).
- **`supabase/migrations/001_schema.sql`** — Vorlage: ENUM um die zwei neuen Werte erweitert, vier CHECK-Constraints konsistent.
- **`supabase/migrations/002_rls.sql`** — Vorlage: WITH-CHECK-Klausel um die zwei neuen Caps und die `dinos_realtime`-Plausibilität ergänzt.

### Score-Caps

| Game | CHECK-Cap | Plausibilität |
|---|---|---|
| `dinos_realtime` | `score <= 200` | `score / duration_seconds <= 0.05` (max ~1 Generation pro 20 s) |
| `dinos_turn` | `score <= 5000` | nur globale `<= 100000`-Klausel; Mindest-Aktionen-Check kommt clientseitig in `logic.js` (keine neue DB-Constraint) |

## ⚠️ Manuelle Anwendung in zwei Schritten

`004_dinos.sql` muss im Supabase-SQL-Editor in **zwei getrennten Läufen** ausgeführt werden:

1. **Section A zuerst**: nur die zwei `ALTER TYPE … ADD VALUE`-Zeilen — `ALTER TYPE` darf in PostgreSQL nicht innerhalb einer Transaktion laufen.
2. **Section B danach**: ab `BEGIN;` bis `COMMIT;` — CHECK-Constraints + Policy-Replace in einer Transaktion (sonst kurzes Default-Deny-Fenster, in dem prod-Inserts blockieren würden).

Header-Kommentar der Datei erklärt das ebenfalls inline.

## Test plan

- [x] `npm run build` grün, Bundle unverändert (1.37 kB JS, 11.18 kB CSS)
- [x] keine Edits an alten Migrationen außer additive Vorlagen-Konsistenz in 001/002
- [ ] User führt Section A + Section B nach Merge im Supabase-Dashboard aus
- [ ] Smoke-Test nach Apply: Insert mit `game=dinos_realtime, score=201` muss von der DB abgewiesen werden (Cap), Insert mit `game=dinos_realtime, score=10, duration_seconds=10` muss abgewiesen werden (Plausibilität)

Schließt nichts — #26 bleibt offen, Phasen 3–6 folgen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@