### PR TITLE
Dino-Evo Score-Cap-Recalibration: 005_dinos_recalibrate.sql (#36)

### DIFF
--- a/docs/dinos-status.md
+++ b/docs/dinos-status.md
@@ -45,7 +45,6 @@ Lokal, noch nicht committet:
 
 ## Phase 3 — Bekannte Lücken / offene Punkte
 
-- **Score-Cap-Mismatch (wichtig)**: Score-Formel `gen·10 + biomes·5 + floor(peakPop/50)` aus Phase 0 vs. DB-Plausibilität `score/duration ≤ 0.05` (in `004_dinos.sql`) sind nicht konsistent — schon nach 1 Generation (60 s) liefert die Formel 10–20 Punkte, das verletzt 0.05/s = max 3 Punkte/min. Page fängt das durch `Math.min(rawScore, floor(0.05*duration), 200)` defensiv ab und zeigt eine Notiz „(nach Balance-Cap)" im Game-Over-Overlay. **Saubere Lösung** ist in Phase 4 oder 5 fällig: entweder Score-Formel reduzieren (Faktor ~0.3) **oder** `005_dinos_recalibrate.sql` mit lockerer Plausibilität (alte Migration nicht editieren). Maintainer-Entscheidung.
 - **Turn-Mode**: Picker zeigt den Button, `createState({mode:'turn',…})` wird gerufen, GA-Phasen laufen synchron via `endTurn`. Aber zwischen den Aktionen passiert visuell nichts, weil `loop()` für `turn` `dt=0` benutzt. Phase 4 ist explizit dafür da.
 - **Mobile-Touch**: Pikmin-Stil-Waypoint reagiert auf `click` (funktioniert auf Touch), aber kein dezidierter Touch-Pfad oder D-Pad. Mobile-Layout-Test steht aus.
 - **Renderer-Polish**: Player-Herd-Mitglieder stapeln sich am Waypoint (kein Spread/Formation). Pop-Trend-Pfeile in den Biom-Karten fehlen — bisher nur Zahl.
@@ -65,7 +64,7 @@ Schon hart in `src/games/dinos/logic/state.js` codiert (PR #28). Nur referenzhal
 - **GA**: BLX-α (α=0.3), Gauß-Mutation (σ=0.08, p=0.15), Tournament-Selection (k=3), 1-Elitismus.
 - **Pop-Caps**: 250 bewegte Entitäten, 4 Biome simultan simuliert (nur aktives gerendert).
 - **Score-Formel**: `gen·10 + biomes·5 + floor(peak_pop/50)`.
-- **DB-Caps**: `dinos_realtime` ≤ 200 (`score/duration <= 0.05`), `dinos_turn` ≤ 5000.
+- **DB-Caps**: `dinos_realtime` ≤ 400 (`score/duration ≤ 0.4`), `dinos_turn` ≤ 5000. Kalibriert via `005_dinos_recalibrate.sql` (Issue #36); ältere Werte (200 / 0.05) waren Einheitenfehler.
 - **Ticks**: Realtime 45–60 s pro Generation (`MIN_GEN_SECONDS=45`), Turn-Mode mind. 3 Spieler-Aktionen pro Generation.
 
 ## Kanonische Quellen

--- a/docs/phase1-spec.md
+++ b/docs/phase1-spec.md
@@ -502,6 +502,12 @@ Keine Zirkel. `step.js` ist die einzige Datei mit allen vier Abhängigkeiten.
 
 ## E. Migration `004_dinos.sql` Review
 
+> **Aktualität:** Die hier dokumentierten Werte (`score <= 200`, `score/duration <= 0.05`)
+> sind die historischen Phase-0-Vorgaben. Sie wurden mit Issue #36 / `005_dinos_recalibrate.sql`
+> auf `400` und `0.4` rekalibriert, weil die Phase-0-Score-Formel mit `0.05` mathematisch
+> kollidierte (Einheitenfehler). Dieser Abschnitt bleibt als Snapshot des Phase-1-Reviews
+> stehen; aktuelle DB-Werte stehen in `docs/dinos-status.md` unter „Verbindliche Werte".
+
 Abgleich gegen `001_schema.sql` + `002_rls.sql` (eingespielter Bestand):
 
 ### E.1 Befunde

--- a/src/pages/dinos.js
+++ b/src/pages/dinos.js
@@ -265,11 +265,13 @@ export function mount(container) {
     const statusEl     = document.getElementById('dn-save-status');
     const leaderboardEl = document.getElementById('dn-leaderboard');
 
-    // DB-Cap (realtime): score ≤ 200 UND score/duration ≤ 0.05.
-    // Der Server lehnt sonst mit 42501 ab — wir cappen defensiv, damit der Save klappt.
+    // DB-Cap (realtime): score ≤ 400 UND score/duration ≤ 0.4 (siehe 005_dinos_recalibrate.sql).
+    // Im Normalfall greift dieser Cap nicht — er bleibt als stille Defense-in-Depth, falls
+    // ein Genie-Run die kalibrierten Werte reißt oder eine ältere Migration in einem Fork
+    // läuft. Kein UI-Hinweis im Capped-Fall: Spieler soll nicht über DB-Limits stolpern.
     const game        = mode === 'turn' ? 'dinos_turn' : 'dinos_realtime';
-    const ratioCap    = mode === 'turn' ? Infinity : Math.floor(0.05 * duration);
-    const absCap      = mode === 'turn' ? 5000 : 200;
+    const ratioCap    = mode === 'turn' ? Infinity : Math.floor(0.4 * duration);
+    const absCap      = mode === 'turn' ? 5000 : 400;
     const saveScoreVal = Math.max(0, Math.min(rawScore, absCap, ratioCap));
 
     const user = await getUser();
@@ -285,11 +287,7 @@ export function mount(container) {
       return;
     }
 
-    if (saveScoreVal < rawScore) {
-      statusEl.textContent = `Score wird gespeichert (${saveScoreVal} nach Balance-Cap)…`;
-    } else {
-      statusEl.textContent = 'Score wird gespeichert…';
-    }
+    statusEl.textContent = 'Score wird gespeichert…';
     try {
       await saveScore(game, saveScoreVal, duration);
       if (destroyed) return;

--- a/supabase/migrations/001_schema.sql
+++ b/supabase/migrations/001_schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE public.scores (
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT tetris_score_limit          CHECK (game <> 'tetris'         OR score <= 10000000),
     CONSTRAINT snake_score_limit           CHECK (game <> 'snake'          OR score <= 100000),
-    CONSTRAINT dinos_realtime_score_limit  CHECK (game <> 'dinos_realtime' OR score <= 200),
+    CONSTRAINT dinos_realtime_score_limit  CHECK (game <> 'dinos_realtime' OR score <= 400),
     CONSTRAINT dinos_turn_score_limit      CHECK (game <> 'dinos_turn'     OR score <= 5000)
 );
 

--- a/supabase/migrations/002_rls.sql
+++ b/supabase/migrations/002_rls.sql
@@ -35,12 +35,12 @@ CREATE POLICY "scores: insert own"
         -- Score limits per game
         AND (game <> 'tetris'          OR score <= 10000000)
         AND (game <> 'snake'           OR score <= 100000)
-        AND (game <> 'dinos_realtime'  OR score <= 200)
+        AND (game <> 'dinos_realtime'  OR score <= 400)
         AND (game <> 'dinos_turn'      OR score <= 5000)
         -- Score/time plausibility (global)
         AND (score::float / duration_seconds) <= 100000
-        -- dinos_realtime: max 0.05 Generationen/Sekunde (sehr langsamer Prozess)
-        AND (game <> 'dinos_realtime' OR (score::float / duration_seconds) <= 0.05)
+        -- dinos_realtime: kalibriert auf Phase-0-Formel (max ~0.5 Pkt/s legitim)
+        AND (game <> 'dinos_realtime' OR (score::float / duration_seconds) <= 0.4)
         -- Rate limiting
         AND public.count_recent_scores(auth.uid(), 3600) < 10
         AND public.count_recent_scores(auth.uid(), 60)   < 2

--- a/supabase/migrations/005_dinos_recalibrate.sql
+++ b/supabase/migrations/005_dinos_recalibrate.sql
@@ -1,0 +1,48 @@
+-- Migration 005: Dino-Evo – Score-Cap-Recalibration
+--
+-- Hintergrund: Phase-0-Score-Formel (gen*10 + biomes*5 + floor(peak_pop/50))
+-- ist mit der Plausibilität aus 004_dinos.sql nicht kompatibel: schon nach
+-- einer Generation (60 s) erreicht der Score ~20 Punkte → ratio 0.33, also
+-- 6× über dem alten Cap von 0.05. Der 0.05-Wert war ein Einheitenfehler
+-- (Generations-Rate vs. Score-Rate).
+--
+-- Diese Migration hebt die DB-Caps auf realistische Phase-0-Werte und macht
+-- den runtime-defensiven Cap in src/pages/dinos.js zur stillen Defense-in-Depth
+-- statt zur regulär greifenden Begrenzung. Anti-Cheat bleibt erhalten:
+-- - Absoluter Cap 400 (statt 200) – Endgame-Score sitzt bei ~328, also ~82 %
+-- - Ratio 0.4 statt 0.05 – legitimer Spike liegt bei ≤0.5, trivialer Spoof bei ≥3
+-- - Rate-Limit (max 9/h, max 1/min) bleibt unverändert
+--
+-- Idempotenz: DROP CONSTRAINT IF EXISTS + DROP POLICY IF EXISTS machen die
+-- Migration re-runnable. ALTER TYPE ist hier nicht nötig (ENUM-Werte stehen
+-- bereits aus 004), daher nur eine Section.
+
+BEGIN;
+
+ALTER TABLE public.scores
+    DROP CONSTRAINT IF EXISTS dinos_realtime_score_limit;
+
+ALTER TABLE public.scores
+    ADD CONSTRAINT dinos_realtime_score_limit
+        CHECK (game <> 'dinos_realtime' OR score <= 400);
+
+DROP POLICY IF EXISTS "scores: insert own" ON public.scores;
+
+CREATE POLICY "scores: insert own"
+    ON public.scores FOR INSERT WITH CHECK (
+        auth.uid() IS NOT NULL
+        -- Score limits per game
+        AND (game <> 'tetris'          OR score <= 10000000)
+        AND (game <> 'snake'           OR score <= 100000)
+        AND (game <> 'dinos_realtime'  OR score <= 400)
+        AND (game <> 'dinos_turn'      OR score <= 5000)
+        -- Score/time plausibility (global)
+        AND (score::float / duration_seconds) <= 100000
+        -- dinos_realtime: kalibriert auf Phase-0-Formel (max ~0.5 Pkt/s legitim)
+        AND (game <> 'dinos_realtime' OR (score::float / duration_seconds) <= 0.4)
+        -- Rate limiting
+        AND public.count_recent_scores(auth.uid(), 3600) < 10
+        AND public.count_recent_scores(auth.uid(), 60)   < 2
+    );
+
+COMMIT;


### PR DESCRIPTION
Closes #36.

## Summary

Hebt die DB-Caps für `dinos_realtime` auf realistische Phase-0-Werte:

| Knob | Alt | Neu |
|---|---|---|
| `dinos_realtime` Score-Cap | 200 | **400** |
| `score / duration_seconds` Ratio | 0.05 | **0.4** |
| `dinos_turn` Score-Cap | 5000 | unverändert |

Die alten Werte waren ein Einheitenfehler (Generations-Rate vs. Score-Rate), siehe Issue #36 für Architect-Begründung. Anti-Cheat-Korridor bleibt: legitimer Spike ≤0.5 Pkt/s, trivialer Client-Spoof ≥3 Pkt/s.

## Changes

- **`supabase/migrations/005_dinos_recalibrate.sql`** (neu): eine Section, eine Transaktion. DROP+CREATE atomar auf CHECK-Constraint und Insert-Policy → kein Default-Deny-Fenster für Production-Inserts. Idempotent via `IF EXISTS`.
- **`supabase/migrations/001_schema.sql`** (Vorlage): `dinos_realtime_score_limit` von `<= 200` auf `<= 400`.
- **`supabase/migrations/002_rls.sql`** (Vorlage): WITH-CHECK Score-Cap auf 400, Ratio auf 0.4.
- **`src/pages/dinos.js#endGame`**: `ratioCap` und `absCap` auf 0.4 / 400 retuned. Den `if (saveScoreVal < rawScore)`-Block mit „(nach Balance-Cap)"-Hinweis entfernt — der Cap bleibt als stille Defense-in-Depth, im kalibrierten Zustand greift er fast nie.
- **`docs/dinos-status.md`**: „Score-Cap-Mismatch"-Punkt aus „Bekannte Lücken" entfernt, „Verbindliche Werte"-Block auf neue DB-Caps aktualisiert.

## Branch / Dependency

- Basiert auf `dinos-phase3-realtime` (PR #30), weil `src/pages/dinos.js` und `docs/dinos-status.md` von dort kommen. **Bitte erst #30 mergen, dann diesen PR rebasen oder mit `--base main` neu zielen.** Aktuell zeigt `--base dinos-phase3-realtime`, der Diff bleibt auch nach Rebase auf `main` derselbe.

## Maintainer-TODO vor Merge

Migration 005 manuell im Supabase-SQL-Editor anwenden (eine Section, BEGIN/COMMIT umschließt DROP+CREATE atomar):

```sql
-- supabase/migrations/005_dinos_recalibrate.sql
```

## Verifikation (im Supabase-SQL-Editor als angemeldeter User)

```sql
-- Soll klappen — sitzt unter Cap und Ratio
INSERT INTO scores (game, score, duration_seconds) VALUES ('dinos_realtime', 350, 1800);

-- Soll fail-en — über absolutem Cap (400)
INSERT INTO scores (game, score, duration_seconds) VALUES ('dinos_realtime', 401, 1800);

-- Soll fail-en — Ratio 1.0 > 0.4
INSERT INTO scores (game, score, duration_seconds) VALUES ('dinos_realtime', 100, 100);

-- Soll klappen — Ratio 0.3 < 0.4
INSERT INTO scores (game, score, duration_seconds) VALUES ('dinos_realtime', 30, 100);
```

## Test plan

- [x] `npm test` → 31/31 grün (kein Logic-Code geändert, Smoke-Check)
- [ ] Migration 005 im Supabase-SQL-Editor angewendet
- [ ] 4 Verifikations-Inserts oben laufen wie erwartet
- [ ] Realtime-Run im Browser → Game-Over → Score speichert ohne UI-„nach-Balance-Cap"-Notiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)