### PR TITLE
test(dinos): regression for #39 + close #32/#35

### DIFF
--- a/src/games/dinos/logic/step.test.js
+++ b/src/games/dinos/logic/step.test.js
@@ -81,6 +81,19 @@ describe('step — Phasen-Übergänge (Turn-Mode)', () => {
     expect(result.phase).toBe(PHASE.SIMULATING);
   });
 
+  it('endTurn ohne echte Aktionen zählt nicht (Regression #39)', () => {
+    // Bug #39: dreimal Q drücken durfte den Button freischalten, indem der
+    // Fallback-Zweig in endTurn den Counter selbst hochzählte. Counter muss 0
+    // bleiben und der Button (Bedingung: actions ≥ MIN) gesperrt sein.
+    let s = createState({ mode: 'turn', seed: 1 });
+    s = step(s, 0, 'start');
+    for (let i = 0; i < TURN_MIN_ACTIONS_PER_GEN + 2; i++) {
+      s = step(s, 0, 'endTurn');
+    }
+    expect(s.player.actionsThisGeneration).toBe(0);
+    expect(s.phase).toBe(PHASE.SIMULATING);
+  });
+
   it('Turn-Mode: endTurn nach TURN_MIN_ACTIONS_PER_GEN durchläuft alle GA-Phasen synchron', () => {
     let s = createState({ mode: 'turn', seed: 2 });
     s = step(s, 0, 'start');


### PR DESCRIPTION
## Summary

Beim Aufräumen offener Issues hat sich gezeigt, dass drei Bugs bereits durch Phase-4/-5 mit-erschlagen wurden — aber nie geschlossen.

- **#32** (Turn-Mode Freeze) → Behoben in `89c9328` (Phase 4): `loop()` in `src/pages/dinos.js:271-272` ruft jetzt auch im Turn-Mode `step(state, 0, null)` pro Frame auf. Inline-Kommentar verweist explizit auf #32.
- **#35** (`resolveEncounter` No-Op) → Behoben in `3990269` (Phase 5): `src/games/dinos/logic/world.js:113-159` enthält jetzt die voll implementierte Resolver-Funktion (Stärken-basierte Auflösung, getrennte fight/flee-Pfade, deterministische Opferauswahl).
- **#39** (Q umgeht 3-Aktionen-Minimum) → Behoben im aktuellen `step.js:66-78` (Fallback-Zweig inkrementiert `actionsThisGeneration` nicht mehr; Kommentar verweist auf #39). **Diese PR fügt den Regressionstest hinzu**, damit das nicht stillschweigend zurückkommen kann.

## Test plan

- [x] `npm test` — alle 56 Tests grün (vorher 55)
- [x] Neuer Test `endTurn ohne echte Aktionen zählt nicht (Regression #39)` prüft, dass 5×`endTurn` ohne setWaypoint/setPace `actionsThisGeneration === 0` lässt und `phase === SIMULATING` bleibt
- [x] Manuelle Verifikation im Browser entfällt — der Test deckt das step.js-Verhalten ab, und die UI hängt rein am state-Wert

Closes #32
Closes #35
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)