### PR TITLE
fix(tetris): #47 Next-Piece-Vorschau aktualisiert sich nie

### DIFF
--- a/src/games/tetris/logic.js
+++ b/src/games/tetris/logic.js
@@ -45,8 +45,10 @@ export function createState() {
   let bag = createBag();
   let nextBag = createBag();
 
-  const current = spawnPiece(bag.shift());
-  const next = spawnPiece(bag.length ? bag[0] : nextBag[0]);
+  const [firstKey, ...restBag] = bag;
+  bag = restBag;
+  const current = spawnPiece(firstKey);
+  const next = previewNext(bag, nextBag);
 
   return {
     board: createBoard(),
@@ -65,12 +67,18 @@ export function createState() {
   };
 }
 
+function previewNext(bag, nextBag) {
+  return spawnPiece(bag.length ? bag[0] : nextBag[0]);
+}
+
 function nextPiece(state) {
-  let { bag, nextBag } = state;
+  let bag = state.bag;
+  let nextBag = state.nextBag;
   if (!bag.length) { bag = nextBag; nextBag = createBag(); }
-  const key = bag.shift();
+  const [key, ...rest] = bag;
+  bag = rest;
   if (!bag.length) { bag = nextBag; nextBag = createBag(); }
-  return { piece: spawnPiece(key), bag, nextBag, nextPieceKey: bag[0] ?? nextBag[0] };
+  return { piece: spawnPiece(key), bag, nextBag };
 }
 
 // Clockwise rotation via matrix transpose + row reverse
@@ -140,12 +148,24 @@ export function dispatch(state, action) {
       const newHeld = { id: current.id, color: current.color, shape: TETROMINOES[
         Object.keys(TETROMINOES).find(k => TETROMINOES[k].id === current.id)
       ].shape.map(r => [...r]) };
-      const nextCurrent = heldKey
-        ? spawnPiece(Object.keys(TETROMINOES).find(k => TETROMINOES[k].id === heldKey.id))
-        : (() => { const n = nextPiece(state); return n.piece; })();
+      if (heldKey) {
+        const nextCurrent = spawnPiece(Object.keys(TETROMINOES).find(k => TETROMINOES[k].id === heldKey.id));
+        if (collides(board, nextCurrent.shape, nextCurrent.x, nextCurrent.y))
+          return { ...state, alive: false };
+        return { ...state, current: nextCurrent, held: newHeld, holdUsed: true };
+      }
+      const { piece: nextCurrent, bag: newBag, nextBag: newNextBag } = nextPiece(state);
       if (collides(board, nextCurrent.shape, nextCurrent.x, nextCurrent.y))
         return { ...state, alive: false };
-      return { ...state, current: nextCurrent, held: newHeld, holdUsed: true };
+      return {
+        ...state,
+        current: nextCurrent,
+        next: previewNext(newBag, newNextBag),
+        bag: newBag,
+        nextBag: newNextBag,
+        held: newHeld,
+        holdUsed: true,
+      };
     }
   }
   return state;
@@ -173,7 +193,7 @@ function lockPiece(state) {
   const newScore = state.score + LINE_SCORES[linesCleared] * (state.level + 1);
 
   // Spawn next piece
-  const { piece: newCurrent, bag, nextBag } = nextPiece({ ...state, bag: [...state.bag], nextBag: [...state.nextBag] });
+  const { piece: newCurrent, bag, nextBag } = nextPiece(state);
 
   if (collides(finalBoard, newCurrent.shape, newCurrent.x, newCurrent.y))
     return { ...state, board: finalBoard, score: newScore, lines: newLines, level: newLevel, alive: false };
@@ -182,6 +202,7 @@ function lockPiece(state) {
     ...state,
     board: finalBoard,
     current: newCurrent,
+    next: previewNext(bag, nextBag),
     bag,
     nextBag,
     holdUsed: false,


### PR DESCRIPTION
## Summary
- `state.next` wurde nur in `createState()` gesetzt und in `lockPiece` sowie im `hold`-Zweig nie aktualisiert — die Sidebar-Vorschau blieb dauerhaft auf dem zweiten Bag-Piece vom Spielstart.
- Zusätzlich verwarf der No-Held-Zweig in `hold` die `bag`/`nextBag`-Updates von `nextPiece(...)`, während `nextPiece` intern via `bag.shift()` `state.bag` mutierte (die defensive Kopie aus `lockPiece` fehlte dort).
- Fix: neuer Helper `previewNext(bag, nextBag)`, in `lockPiece` und im `hold`-No-Held-Zweig explizit gesetzt; `nextPiece`/`createState` non-mutating umgebaut; defensive Kopie in `lockPiece` entfällt.

Closes #47.

## Test plan
- [ ] `npm run dev` → Tetris öffnen, ein paar Steine droppen: „Nächstes"-Vorschau ändert sich nach jedem Lock und stimmt mit dem tatsächlich gespawnten Stein überein.
- [ ] Erste Aktion = Hold (vor Lock): neuer aktiver Stein kommt aus dem Bag, Vorschau zeigt das *nachfolgende* Piece, nicht mehr das alte.
- [ ] Hold mit bereits gehaltenem Piece: Vorschau unverändert (das gehaltene Piece kommt aktiv, kein Bag-Zug).
- [ ] Game-Over per Top-Out (Stack hoch füllen) funktioniert weiterhin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)