### PR TITLE
feat(admin): phase 1 — migration 006 + auth gate + admin route

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,0 +1,69 @@
+import { supabase } from './supabase.js';
+
+let cachedIsAdmin = null;
+let cacheUserId = null;
+
+export function resetAdminCache() {
+  cachedIsAdmin = null;
+  cacheUserId = null;
+}
+
+export async function isAdmin() {
+  // Cache per user-id; invalidate on user switch
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    cachedIsAdmin = false;
+    cacheUserId = null;
+    return false;
+  }
+  if (cacheUserId !== user.id) {
+    cacheUserId = user.id;
+    cachedIsAdmin = null;
+  }
+  if (cachedIsAdmin !== null) return cachedIsAdmin;
+
+  const { data, error } = await supabase.rpc('is_admin');
+  if (error) {
+    cachedIsAdmin = false;
+    return false;
+  }
+  cachedIsAdmin = data === true;
+  return cachedIsAdmin;
+}
+
+function handleError(error) {
+  if (error?.code === '42501') throw new Error('Keine Admin-Berechtigung.');
+  throw error;
+}
+
+export async function listUsers({ limit = 100, offset = 0 } = {}) {
+  const { data, error } = await supabase.rpc('admin_list_users', {
+    p_limit: limit,
+    p_offset: offset,
+  });
+  if (error) handleError(error);
+  return data ?? [];
+}
+
+export async function statsDaily(days = 30) {
+  const { data, error } = await supabase.rpc('admin_stats_daily_fn', {
+    p_days: days,
+  });
+  if (error) handleError(error);
+  return data ?? [];
+}
+
+export async function statsActiveUsers() {
+  const { data, error } = await supabase.rpc('admin_stats_active_users_fn');
+  if (error) handleError(error);
+  return data ?? null;
+}
+
+export async function topPlayers(game, limit = 10) {
+  const { data, error } = await supabase.rpc('admin_top_players', {
+    p_game: game,
+    p_limit: limit,
+  });
+  if (error) handleError(error);
+  return data ?? [];
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ const routes = {
   'tetris': () => import('./pages/tetris.js'),
   'snake':  () => import('./pages/snake.js'),
   'dinos':  () => import('./pages/dinos.js'),
+  'admin':  () => import('./pages/admin/index.js'),
 };
 
 async function router() {

--- a/src/pages/admin/auth-gate.js
+++ b/src/pages/admin/auth-gate.js
@@ -1,0 +1,11 @@
+import { getUser } from '../../api/auth.js';
+import { isAdmin } from '../../api/admin.js';
+
+// Returns user if admin, otherwise redirects to home and returns null.
+export async function ensureAdmin() {
+  const user = await getUser();
+  if (!user) { location.hash = '#/'; return null; }
+  const ok = await isAdmin();
+  if (!ok) { location.hash = '#/'; return null; }
+  return user;
+}

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -1,0 +1,31 @@
+import { ensureAdmin } from './auth-gate.js';
+
+export function mount(container) {
+  let active = true;
+
+  (async () => {
+    const user = await ensureAdmin();
+    if (!active || !user) return;
+
+    container.innerHTML = '';
+
+    const section = document.createElement('section');
+    section.className = 'admin admin-placeholder';
+
+    const h1 = document.createElement('h1');
+    h1.textContent = 'Admin-Bereich';
+
+    const p = document.createElement('p');
+    p.textContent = 'Phase 1: Skelett. Tabs folgen in Phase 2.';
+
+    const small = document.createElement('small');
+    small.textContent = `Angemeldet als ${user.email}`;
+
+    section.append(h1, p, small);
+    container.appendChild(section);
+  })();
+
+  return function destroy() {
+    active = false;
+  };
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -788,3 +788,7 @@ dialog::backdrop {
   #app { padding: 0.75rem; }
   .hero h1 { font-size: 2rem; }
 }
+
+/* ===== Admin area ===== */
+.admin { padding: 2rem 1rem; max-width: 960px; margin: 0 auto; }
+.admin-placeholder small { display: block; margin-top: 1rem; color: var(--text-muted); }

--- a/supabase/migrations/006_admin_core.sql
+++ b/supabase/migrations/006_admin_core.sql
@@ -1,0 +1,270 @@
+-- Migration 006: Admin-Bereich – Kern-Infrastruktur
+--
+-- WICHTIG – Ausführungsreihenfolge im Supabase-SQL-Editor:
+--
+--   Diese Migration enthält KEINE ENUM-Änderungen und kann daher in einem
+--   einzigen Run als vollständige Transaktion ausgeführt werden. Einfach den
+--   gesamten Inhalt im Supabase-SQL-Editor einfügen und ausführen.
+--
+--   Was diese Migration tut:
+--   - Fügt is_admin-Spalte zur profiles-Tabelle hinzu
+--   - Erstellt die Helper-Funktion public.is_admin()
+--   - Erstellt die Tabelle game_settings mit RLS
+--   - Erstellt Admin-Views (admin_users_overview, admin_stats_daily,
+--     admin_stats_active_users) mit security_invoker = true
+--   - Erstellt SECURITY DEFINER RPCs für Admin-Datenzugriff
+--   - Fügt eine zusätzliche RLS-Policy für Admin-Lesezugriff auf profiles hinzu
+
+BEGIN;
+
+-- ============================================================
+-- 1. profiles: is_admin-Spalte
+-- ============================================================
+
+ALTER TABLE public.profiles
+    ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_profiles_is_admin
+    ON public.profiles(is_admin)
+    WHERE is_admin = TRUE;
+
+-- ============================================================
+-- 2. Helper-Funktion is_admin()
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.is_admin(p_user_id UUID DEFAULT auth.uid())
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT COALESCE((SELECT is_admin FROM public.profiles WHERE id = p_user_id), FALSE);
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.is_admin(UUID) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.is_admin(UUID) TO authenticated;
+
+-- ============================================================
+-- 3. game_settings-Tabelle
+-- ============================================================
+
+CREATE TABLE public.game_settings (
+    game             public.game_type PRIMARY KEY,
+    enabled          BOOLEAN NOT NULL DEFAULT TRUE,
+    disabled_message TEXT,
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by       UUID REFERENCES public.profiles(id)
+);
+
+INSERT INTO public.game_settings (game) VALUES
+    ('tetris'),
+    ('snake'),
+    ('dinos_realtime'),
+    ('dinos_turn');
+
+ALTER TABLE public.game_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "game_settings: public read"
+    ON public.game_settings FOR SELECT
+    USING (true);
+
+CREATE POLICY "game_settings: admin update"
+    ON public.game_settings FOR UPDATE
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin());
+
+-- ============================================================
+-- 4. Admin-Views (security_invoker = true, PG15+)
+-- ============================================================
+
+CREATE VIEW public.admin_users_overview
+WITH (security_invoker = true)
+AS
+SELECT
+    p.id,
+    p.display_name,
+    u.email,
+    u.created_at          AS registered_at,
+    u.last_sign_in_at,
+    p.is_admin,
+    COALESCE(sc.score_count, 0) AS score_count,
+    sc.last_score_at
+FROM public.profiles p
+JOIN auth.users u ON u.id = p.id
+LEFT JOIN (
+    SELECT
+        user_id,
+        COUNT(*)              AS score_count,
+        MAX(created_at)       AS last_score_at
+    FROM public.scores
+    GROUP BY user_id
+) sc ON sc.user_id = p.id;
+
+CREATE VIEW public.admin_stats_daily
+WITH (security_invoker = true)
+AS
+SELECT
+    date_trunc('day', created_at)::date  AS day,
+    game,
+    COUNT(*)                             AS scores,
+    COUNT(DISTINCT user_id)              AS unique_players,
+    AVG(duration_seconds)                AS avg_duration
+FROM public.scores
+GROUP BY date_trunc('day', created_at)::date, game;
+
+CREATE VIEW public.admin_stats_active_users
+WITH (security_invoker = true)
+AS
+SELECT
+    COUNT(DISTINCT user_id) FILTER (WHERE created_at >= NOW() - INTERVAL '1 day')   AS dau,
+    COUNT(DISTINCT user_id) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days')  AS wau,
+    COUNT(DISTINCT user_id) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS mau
+FROM public.scores;
+
+-- ============================================================
+-- 5. Admin-RPCs (SECURITY DEFINER, mit is_admin()-Guard)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.admin_list_users(
+    p_limit  INT DEFAULT 100,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    id              UUID,
+    display_name    VARCHAR,
+    email           TEXT,
+    registered_at   TIMESTAMPTZ,
+    last_sign_in_at TIMESTAMPTZ,
+    is_admin        BOOLEAN,
+    score_count     BIGINT,
+    last_score_at   TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        v.id,
+        v.display_name,
+        v.email,
+        v.registered_at,
+        v.last_sign_in_at,
+        v.is_admin,
+        v.score_count,
+        v.last_score_at
+    FROM public.admin_users_overview v
+    ORDER BY v.registered_at DESC
+    LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_stats_daily_fn(p_days INT DEFAULT 30)
+RETURNS TABLE (
+    day            DATE,
+    game           public.game_type,
+    scores         BIGINT,
+    unique_players BIGINT,
+    avg_duration   NUMERIC
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        v.day,
+        v.game,
+        v.scores,
+        v.unique_players,
+        v.avg_duration
+    FROM public.admin_stats_daily v
+    WHERE v.day >= (CURRENT_DATE - (p_days - 1))
+    ORDER BY v.day DESC, v.game;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_stats_active_users_fn()
+RETURNS TABLE (dau BIGINT, wau BIGINT, mau BIGINT)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT v.dau, v.wau, v.mau
+    FROM public.admin_stats_active_users v;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_top_players(
+    p_game  public.game_type,
+    p_limit INT DEFAULT 10
+)
+RETURNS TABLE (
+    display_name VARCHAR,
+    score        INTEGER,
+    created_at   TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT p.display_name, s.score, s.created_at
+    FROM public.scores s
+    JOIN public.profiles p ON p.id = s.user_id
+    WHERE s.game = p_game
+    ORDER BY s.score DESC
+    LIMIT p_limit;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_list_users(INT, INT)        FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_list_users(INT, INT)        TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.admin_stats_daily_fn(INT)         FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_stats_daily_fn(INT)         TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.admin_stats_active_users_fn()     FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_stats_active_users_fn()     TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.admin_top_players(public.game_type, INT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_top_players(public.game_type, INT) TO authenticated;
+
+-- ============================================================
+-- 6. RLS: Admin darf alle Profile lesen
+-- ============================================================
+
+-- Additiv zur bestehenden "profiles: select own"-Policy — RLS-Policies sind
+-- OR-verknüpft (permissive), diese Schicht erlaubt Admins Lesezugriff auf
+-- alle Zeilen und bereitet strikte Verschärfung für andere Rollen vor.
+CREATE POLICY "profiles: admin read all"
+    ON public.profiles FOR SELECT
+    USING (public.is_admin());
+
+COMMIT;


### PR DESCRIPTION
## Summary

Phase 1 des Admin-Bereichs (Tracking-Issue #49): Skelett mit DB-Grundlage, versteckter Route und Auth-Gate. **Noch keine Tabs/UI-Features** — die folgen in Phase 2+.

- Migration `006_admin_core.sql`: `profiles.is_admin`, `is_admin()`-Helper, `game_settings`-Tabelle, 3 Admin-Views (`security_invoker = true`), 4 RPCs (`SECURITY DEFINER` + `is_admin()`-Guard), `REVOKE EXECUTE FROM PUBLIC; GRANT TO authenticated;`, zusätzliche RLS-Policy für Admin-Read auf `profiles`.
- `src/api/admin.js`: dünner RPC-Wrapper analog `scores.js`, mit Session-scoped `is_admin`-Cache (`resetAdminCache()` exportiert für künftige `onAuthChange`-Verkabelung).
- `src/pages/admin/{auth-gate,index}.js`: `ensureAdmin()` redirected Nicht-Admins nach `#/`; Platzhalter-Page mit Lifecycle.
- `src/main.js`: Route `'admin'` ergänzt (Lazy-Import). **Kein UI-Link** in `nav.js` — Admin-Zugang nur per direktem `#/admin`.
- `src/styles/main.css`: Namespace `.admin-*` (verwendet bestehende `--text-muted`).

## Sicherheits-Anker

- Doppelter Auth-Check: Client-Gate (`ensureAdmin()`) **und** server-seitig (jede RPC mit `IF NOT public.is_admin() THEN RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501'`).
- Views mit `security_invoker = true` — direkte Queries durch Nicht-Admins liefern nichts; nur via `SECURITY DEFINER`-RPC mit Guard.
- Kein Service-Role-Key. Erste Admin-Promotion ausschließlich manuell im SQL-Editor.

## Manuelle Schritte vor Merge

1. Migration `006_admin_core.sql` im Supabase-SQL-Editor einspielen (eine Transaktion, keine ENUM-Änderung, ein Run reicht).
2. Mindestens einen Admin promoten: `UPDATE public.profiles SET is_admin = TRUE WHERE id = '<deine-uuid>';`

## Test plan

- [ ] Migration im Supabase-Editor laufen lassen, keine Fehler
- [ ] Mit normalem User `#/admin` aufrufen → Redirect nach `#/`
- [ ] Mit promovierem Admin `#/admin` aufrufen → Platzhalter-Page erscheint, E-Mail wird angezeigt
- [ ] `npm run build` läuft durch (geprüft, 562 ms, 10 Chunks)
- [ ] Bestehende Spiele (Tetris/Snake/Dinos) funktionieren unverändert

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)