### PR TITLE
feat(admin): phase 2 — tab skeleton with 6 placeholder modules

### DIFF
--- a/src/pages/admin/announcements.js
+++ b/src/pages/admin/announcements.js
@@ -1,0 +1,12 @@
+export function mount(container) {
+  const section = document.createElement('section');
+  section.className = 'admin-tab admin-tab-announcements';
+  const p = document.createElement('p');
+  p.className = 'admin-placeholder-text';
+  p.textContent = 'Banner-Verwaltung — folgt in Phase 9.';
+  section.appendChild(p);
+  container.appendChild(section);
+  return function destroy() {
+    // Phase-2-Platzhalter: noch nichts zu cleanen
+  };
+}

--- a/src/pages/admin/audit.js
+++ b/src/pages/admin/audit.js
@@ -1,0 +1,12 @@
+export function mount(container) {
+  const section = document.createElement('section');
+  section.className = 'admin-tab admin-tab-audit';
+  const p = document.createElement('p');
+  p.className = 'admin-placeholder-text';
+  p.textContent = 'Audit-Log — folgt in Phase 7.';
+  section.appendChild(p);
+  container.appendChild(section);
+  return function destroy() {
+    // Phase-2-Platzhalter: noch nichts zu cleanen
+  };
+}

--- a/src/pages/admin/games.js
+++ b/src/pages/admin/games.js
@@ -1,0 +1,12 @@
+export function mount(container) {
+  const section = document.createElement('section');
+  section.className = 'admin-tab admin-tab-games';
+  const p = document.createElement('p');
+  p.className = 'admin-placeholder-text';
+  p.textContent = 'Spiele-Verwaltung — folgt in Phase 4.';
+  section.appendChild(p);
+  container.appendChild(section);
+  return function destroy() {
+    // Phase-2-Platzhalter: noch nichts zu cleanen
+  };
+}

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -1,7 +1,19 @@
 import { ensureAdmin } from './auth-gate.js';
 
+const TABS = [
+  { name: 'users',         label: 'Nutzer' },
+  { name: 'games',         label: 'Spiele' },
+  { name: 'stats',         label: 'Statistiken' },
+  { name: 'moderation',    label: 'Moderation' },
+  { name: 'audit',         label: 'Audit-Log' },
+  { name: 'announcements', label: 'Banner' },
+];
+
 export function mount(container) {
   let active = true;
+  let currentTabName = null;
+  let currentTabDestroy = null;
+  const tabBtnListeners = [];
 
   (async () => {
     const user = await ensureAdmin();
@@ -9,23 +21,101 @@ export function mount(container) {
 
     container.innerHTML = '';
 
-    const section = document.createElement('section');
-    section.className = 'admin admin-placeholder';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'admin';
+
+    // Header
+    const header = document.createElement('header');
+    header.className = 'admin-header';
 
     const h1 = document.createElement('h1');
     h1.textContent = 'Admin-Bereich';
 
-    const p = document.createElement('p');
-    p.textContent = 'Phase 1: Skelett. Tabs folgen in Phase 2.';
-
     const small = document.createElement('small');
-    small.textContent = `Angemeldet als ${user.email}`;
+    small.className = 'admin-user';
+    small.textContent = 'Angemeldet als ';
+    const emailSpan = document.createElement('span');
+    emailSpan.textContent = user.email;
+    small.appendChild(emailSpan);
 
-    section.append(h1, p, small);
-    container.appendChild(section);
+    header.append(h1, small);
+
+    // Tab bar
+    const nav = document.createElement('nav');
+    nav.className = 'admin-tabs';
+    nav.setAttribute('role', 'tablist');
+
+    // Tab content area
+    const content = document.createElement('div');
+    content.className = 'admin-tab-content';
+    content.id = 'admin-tab-content';
+
+    async function switchTab(name) {
+      if (name === currentTabName) return;
+
+      if (currentTabDestroy) {
+        currentTabDestroy();
+        currentTabDestroy = null;
+      }
+      content.innerHTML = '';
+      currentTabName = name;
+
+      // Update active button state
+      nav.querySelectorAll('.admin-tab-btn').forEach(btn => {
+        const isActive = btn.dataset.tab === name;
+        btn.classList.toggle('active', isActive);
+        if (isActive) {
+          btn.setAttribute('aria-current', 'page');
+        } else {
+          btn.removeAttribute('aria-current');
+        }
+      });
+
+      if (!active) return;
+
+      const imports = {
+        users:         () => import('./users.js'),
+        games:         () => import('./games.js'),
+        stats:         () => import('./stats.js'),
+        moderation:    () => import('./moderation.js'),
+        audit:         () => import('./audit.js'),
+        announcements: () => import('./announcements.js'),
+      };
+      const mod = await imports[name]();
+      if (!active) return;
+      currentTabDestroy = mod.mount(content);
+    }
+
+    TABS.forEach(tab => {
+      const btn = document.createElement('button');
+      btn.className = 'admin-tab-btn';
+      btn.dataset.tab = tab.name;
+      btn.textContent = tab.label;
+      btn.type = 'button';
+
+      const handler = () => switchTab(tab.name);
+      btn.addEventListener('click', handler);
+      tabBtnListeners.push({ btn, handler });
+
+      nav.appendChild(btn);
+    });
+
+    wrapper.append(header, nav, content);
+    container.appendChild(wrapper);
+
+    // Mount default tab
+    await switchTab('users');
   })();
 
   return function destroy() {
     active = false;
+    if (currentTabDestroy) {
+      currentTabDestroy();
+      currentTabDestroy = null;
+    }
+    tabBtnListeners.forEach(({ btn, handler }) => {
+      btn.removeEventListener('click', handler);
+    });
+    tabBtnListeners.length = 0;
   };
 }

--- a/src/pages/admin/moderation.js
+++ b/src/pages/admin/moderation.js
@@ -1,0 +1,12 @@
+export function mount(container) {
+  const section = document.createElement('section');
+  section.className = 'admin-tab admin-tab-moderation';
+  const p = document.createElement('p');
+  p.className = 'admin-placeholder-text';
+  p.textContent = 'Moderation — folgt in Phase 8.';
+  section.appendChild(p);
+  container.appendChild(section);
+  return function destroy() {
+    // Phase-2-Platzhalter: noch nichts zu cleanen
+  };
+}

--- a/src/pages/admin/stats.js
+++ b/src/pages/admin/stats.js
@@ -1,0 +1,12 @@
+export function mount(container) {
+  const section = document.createElement('section');
+  section.className = 'admin-tab admin-tab-stats';
+  const p = document.createElement('p');
+  p.className = 'admin-placeholder-text';
+  p.textContent = 'Statistiken — folgen in Phase 5.';
+  section.appendChild(p);
+  container.appendChild(section);
+  return function destroy() {
+    // Phase-2-Platzhalter: noch nichts zu cleanen
+  };
+}

--- a/src/pages/admin/users.js
+++ b/src/pages/admin/users.js
@@ -1,0 +1,12 @@
+export function mount(container) {
+  const section = document.createElement('section');
+  section.className = 'admin-tab admin-tab-users';
+  const p = document.createElement('p');
+  p.className = 'admin-placeholder-text';
+  p.textContent = 'Nutzer-Verwaltung — folgt in Phase 3.';
+  section.appendChild(p);
+  container.appendChild(section);
+  return function destroy() {
+    // Phase-2-Platzhalter: noch nichts zu cleanen
+  };
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -794,4 +794,12 @@ dialog::backdrop {
 
 /* ===== Admin area ===== */
 .admin { padding: 2rem 1rem; max-width: 960px; margin: 0 auto; }
-.admin-placeholder small { display: block; margin-top: 1rem; color: var(--text-muted); }
+.admin-header { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
+.admin-header h1 { margin: 0; }
+.admin-user { color: var(--text-muted); font-size: 0.9rem; }
+.admin-tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid rgba(255,255,255,0.1); margin-bottom: 1.5rem; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.admin-tab-btn { background: transparent; border: none; padding: 0.6rem 1rem; color: var(--text-muted); font: inherit; cursor: pointer; border-bottom: 2px solid transparent; white-space: nowrap; }
+.admin-tab-btn:hover { color: var(--text); }
+.admin-tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+.admin-tab-content { min-height: 200px; }
+.admin-placeholder-text { color: var(--text-muted); }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -797,7 +797,7 @@ dialog::backdrop {
 .admin-header { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
 .admin-header h1 { margin: 0; }
 .admin-user { color: var(--text-muted); font-size: 0.9rem; }
-.admin-tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid rgba(255,255,255,0.1); margin-bottom: 1.5rem; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.admin-tabs { display: flex; gap: 0.25rem; border-bottom: 1px solid var(--border-subtle); margin-bottom: 1.5rem; overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .admin-tab-btn { background: transparent; border: none; padding: 0.6rem 1rem; color: var(--text-muted); font: inherit; cursor: pointer; border-bottom: 2px solid transparent; white-space: nowrap; }
 .admin-tab-btn:hover { color: var(--text); }
 .admin-tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }


### PR DESCRIPTION
## Summary

Phase 2 des Admin-Bereichs (Tracking-Issue #49): Tab-Skelett mit sechs leeren Tab-Modulen als Vorbereitung für die Feature-Phasen 3–9. **Noch keine Tab-Funktionalität** — jedes Modul rendert nur einen Platzhalter-Text.

- `src/pages/admin/index.js`: Vollständig neu strukturiert als Tab-Switching-Page. Header (`Admin-Bereich`, E-Mail), `<nav role="tablist">` mit sechs `<button>`-Tabs, Content-Area, Tab-Switch mit korrektem destroy-Lifecycle des Sub-Tabs vor neuem mount. Default-Tab: `users`. Page-`destroy()` cleant active-Flag + Sub-Tab + alle Click-Listener.
- `src/pages/admin/{users,games,stats,moderation,audit,announcements}.js`: minimale `mount/destroy`-Module mit Platzhalter-Text und Verweis auf die Ziel-Phase (z. B. „Audit-Log — folgt in Phase 7.").
- `src/styles/main.css`: Tab-Bar-Styles (`admin-header`, `admin-tabs`, `admin-tab-btn` inkl. hover/active, `admin-tab-content`). Mobile: `overflow-x: auto`. Phase-1-Regel `.admin-placeholder small` entfernt.

## Lazy-Loading

Statt `import(\`./\${name}.js\`)` (für Vite nicht statisch analysierbar) wurde eine explizite Import-Map mit sechs `import()`-Aufrufen verwendet. Vite emittiert damit sauber sechs eigene Chunks (jeweils ~0.3 kB gzipped).

## Sicherheits-Anker

- `ensureAdmin()`-Gate bleibt unverändert aus Phase 1 — gilt für alle Tabs.
- Tab-Module sind reine UI-Platzhalter, keine RPCs, keine User-Daten.
- E-Mail-Anzeige via `textContent` (XSS-safe).

## Test plan

- [ ] `npm run build` läuft durch (geprüft, 575 ms, 16 Chunks inkl. 6 Tab-Chunks)
- [ ] `#/admin` mit Admin-User: Tab-Bar mit sechs Tabs sichtbar, „Nutzer" ist aktiv
- [ ] Tab-Wechsel: Inhalt tauscht aus, aktiver Button visuell hervorgehoben
- [ ] Mobile-Viewport (≤480 px): Tab-Bar ist horizontal scrollbar
- [ ] Routen-Wechsel weg von `#/admin`: keine Konsolen-Fehler (destroy-Cascade funktioniert)

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)