### PR TITLE
feat(admin): phase 3 — users tab with table, pagination, client-side filter

### DIFF
--- a/src/pages/admin/users.js
+++ b/src/pages/admin/users.js
@@ -1,12 +1,210 @@
+import { listUsers } from '../../api/admin.js';
+
+const LIMIT = 50;
+
+function formatDate(val) {
+  if (!val) return '—';
+  return new Date(val).toLocaleDateString('de-DE');
+}
+
+function buildRow(user) {
+  const tr = document.createElement('tr');
+
+  const cells = [
+    { text: user.display_name ?? '—', cls: null },
+    { text: user.email ?? '—', cls: null },
+    { text: formatDate(user.registered_at), cls: null },
+    { text: formatDate(user.last_sign_in_at), cls: null },
+    { text: String(user.score_count ?? 0), cls: 'col-num' },
+    { text: formatDate(user.last_score_at), cls: 'col-num' },
+    { text: user.is_admin ? '✓' : '', cls: null },
+  ];
+
+  for (const { text, cls } of cells) {
+    const td = document.createElement('td');
+    td.textContent = text;
+    if (cls) td.className = cls;
+    tr.appendChild(td);
+  }
+
+  return tr;
+}
+
 export function mount(container) {
+  let active = true;
+  let currentOffset = 0;
+  let lastPageSize = 0;
+  let allRows = []; // rows from current page for client-side filter
+
+  // --- Build skeleton DOM ---
   const section = document.createElement('section');
-  section.className = 'admin-tab admin-tab-users';
-  const p = document.createElement('p');
-  p.className = 'admin-placeholder-text';
-  p.textContent = 'Nutzer-Verwaltung — folgt in Phase 3.';
-  section.appendChild(p);
+  section.className = 'admin-users';
+
+  // Toolbar
+  const toolbar = document.createElement('div');
+  toolbar.className = 'admin-users-toolbar';
+
+  const searchInput = document.createElement('input');
+  searchInput.type = 'search';
+  searchInput.placeholder = 'Filter nach Name oder E-Mail …';
+  searchInput.className = 'admin-users-search';
+  searchInput.title = 'Filter wirkt nur auf aktuelle Seite';
+
+  const pageInfo = document.createElement('span');
+  pageInfo.className = 'admin-users-page-info';
+
+  toolbar.appendChild(searchInput);
+  toolbar.appendChild(pageInfo);
+
+  // Table wrapper (for mobile overflow)
+  const tableWrap = document.createElement('div');
+  tableWrap.className = 'admin-table-wrap';
+
+  const table = document.createElement('table');
+  table.className = 'admin-table';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  for (const label of ['Name', 'E-Mail', 'Registriert', 'Zuletzt aktiv', 'Scores', 'Letzter Score', 'Admin']) {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+
+  const tbody = document.createElement('tbody');
+  table.appendChild(thead);
+  table.appendChild(tbody);
+  tableWrap.appendChild(table);
+
+  // Pagination
+  const pagination = document.createElement('div');
+  pagination.className = 'admin-users-pagination';
+
+  const btnBack = document.createElement('button');
+  btnBack.textContent = '← Zurück';
+  btnBack.disabled = true;
+
+  const pageIndicator = document.createElement('span');
+  pageIndicator.className = 'admin-users-page-indicator';
+
+  const btnNext = document.createElement('button');
+  btnNext.textContent = 'Weiter →';
+  btnNext.disabled = true;
+
+  pagination.appendChild(btnBack);
+  pagination.appendChild(pageIndicator);
+  pagination.appendChild(btnNext);
+
+  section.appendChild(toolbar);
+  section.appendChild(tableWrap);
+  section.appendChild(pagination);
   container.appendChild(section);
+
+  // --- Helpers ---
+  function setTbodyMessage(text, cls) {
+    tbody.innerHTML = '';
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 7;
+    td.className = cls;
+    td.textContent = text;
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  }
+
+  function applyFilter(query) {
+    const q = query.trim().toLowerCase();
+    tbody.innerHTML = '';
+
+    const visible = q
+      ? allRows.filter(({ user }) =>
+          (user.display_name ?? '').toLowerCase().includes(q) ||
+          (user.email ?? '').toLowerCase().includes(q)
+        )
+      : allRows;
+
+    if (visible.length === 0) {
+      setTbodyMessage('Keine Nutzer auf dieser Seite.', 'admin-empty');
+      return;
+    }
+
+    for (const { row } of visible) {
+      tbody.appendChild(row);
+    }
+  }
+
+  async function loadPage(offset) {
+    currentOffset = offset;
+    searchInput.value = '';
+    btnBack.disabled = true;
+    btnNext.disabled = true;
+    allRows = [];
+
+    const currentPage = Math.floor(offset / LIMIT) + 1;
+    pageIndicator.textContent = `Seite ${currentPage}`;
+    pageInfo.textContent = '';
+
+    setTbodyMessage('Lade Nutzer …', 'admin-loading');
+
+    let data;
+    try {
+      data = await listUsers({ limit: LIMIT, offset });
+    } catch (err) {
+      if (!active) return;
+      setTbodyMessage(`Konnte Nutzer nicht laden: ${err.message}`, 'admin-error');
+      return;
+    }
+
+    if (!active) return;
+
+    lastPageSize = data.length;
+
+    if (data.length === 0) {
+      setTbodyMessage('Keine Nutzer auf dieser Seite.', 'admin-empty');
+    } else {
+      allRows = data.map(user => ({ user, row: buildRow(user) }));
+      tbody.innerHTML = '';
+      for (const { row } of allRows) {
+        tbody.appendChild(row);
+      }
+    }
+
+    const from = offset + 1;
+    const to = offset + data.length;
+    pageInfo.textContent = data.length > 0 ? `${from}–${to}` : '';
+    pageIndicator.textContent = `Seite ${currentPage}`;
+
+    btnBack.disabled = offset === 0;
+    btnNext.disabled = lastPageSize < LIMIT;
+  }
+
+  // --- Event handlers ---
+  function onSearch(e) {
+    applyFilter(e.target.value);
+  }
+
+  function onBack() {
+    if (currentOffset === 0) return;
+    loadPage(currentOffset - LIMIT);
+  }
+
+  function onNext() {
+    if (lastPageSize < LIMIT) return;
+    loadPage(currentOffset + LIMIT);
+  }
+
+  searchInput.addEventListener('input', onSearch);
+  btnBack.addEventListener('click', onBack);
+  btnNext.addEventListener('click', onNext);
+
+  // Initial load
+  loadPage(0);
+
   return function destroy() {
-    // Phase-2-Platzhalter: noch nichts zu cleanen
+    active = false;
+    searchInput.removeEventListener('input', onSearch);
+    btnBack.removeEventListener('click', onBack);
+    btnNext.removeEventListener('click', onNext);
   };
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -803,3 +803,81 @@ dialog::backdrop {
 .admin-tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
 .admin-tab-content { min-height: 200px; }
 .admin-placeholder-text { color: var(--text-muted); }
+
+/* ===== Admin – Users tab ===== */
+.admin-users-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.admin-users-search {
+  padding: 0.5rem 0.75rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+  flex: 1 1 220px;
+  min-width: 0;
+}
+.admin-users-search:focus { outline: 2px solid var(--accent); border-color: transparent; }
+
+.admin-users-page-info { color: var(--text-muted); font-size: 0.875rem; white-space: nowrap; }
+
+.admin-table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
+.admin-table { width: 100%; border-collapse: collapse; }
+
+.admin-table th,
+.admin-table td {
+  padding: 0.55rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.admin-table th {
+  background: var(--surface);
+  font-weight: 500;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.admin-table tbody tr:hover { background: var(--surface2); }
+
+.admin-table .col-num { text-align: right; }
+
+.admin-users-pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.admin-users-pagination button {
+  padding: 0.4rem 0.85rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.admin-users-pagination button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.admin-users-pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.admin-users-page-indicator { color: var(--text-muted); font-size: 0.875rem; }
+
+.admin-loading { color: var(--text-muted); font-size: 0.9rem; padding: 0.5rem 0.75rem; }
+.admin-error   { color: var(--danger);     font-size: 0.9rem; padding: 0.5rem 0.75rem; }
+.admin-empty   { color: var(--text-muted); font-size: 0.9rem; padding: 0.5rem 0.75rem; }
+
+@media (max-width: 640px) {
+  .admin-users-toolbar { flex-direction: column; align-items: stretch; }
+  .admin-users-search  { flex: 1 1 auto; }
+}


### PR DESCRIPTION
## Summary

Phase 3 des Admin-Bereichs (Tracking-Issue #49): vollständiger Nutzer-Tab mit Tabelle, Pagination und clientseitigem Filter. Der Phase-2-Platzhalter wird ersetzt.

- `src/pages/admin/users.js`: Tabelle mit 7 Spalten (Name, E-Mail, Registriert, Zuletzt aktiv, Scores, Letzter Score, Admin). Daten via `admin_list_users`-RPC aus Phase 1. Alle dynamischen Werte über `textContent`. Datumsformat `de-DE`.
- Offset-Pagination, `LIMIT=50`. „Zurück" disabled bei `offset === 0`; „Weiter" disabled, wenn die letzte Page weniger als `LIMIT` Zeilen hatte (Heuristik — die RPC liefert kein Total-Count).
- Suchfeld filtert die **aktuell geladene Seite** clientseitig (Substring auf Name+E-Mail, case-insensitive). Server-Side-Search erfordert eine zusätzliche RPC und ist aufgeschoben.
- Loading/Error/Empty-States im `<tbody>` via `<td colspan="7">`.
- `active`-Flag im `mount()` ignoriert späte async-Resolutions nach Tab-Wechsel. `destroy()` entfernt alle Listener.
- `src/styles/main.css`: `admin-users-*` und `admin-table-*` mit den semantischen Border-Tokens. Mobile-Anpassung (`@media (max-width: 640px)`): Toolbar stackt, Tabelle ist in einem Wrapper horizontal scrollbar.

## Sicherheits-Anker

- Kein `innerHTML` mit Variablen — alle 3 Vorkommen sind `tbody.innerHTML = ''` zum Leeren, kein User-Daten-Einsatz.
- E-Mail-Spalte mit `textContent` (DB-Constraint validiert E-Mail-Format nicht — Defense in Depth).
- `admin_list_users` ist `SECURITY DEFINER` mit `is_admin()`-Guard — Nicht-Admins bekommen `42501`.

## Test plan

- [x] `npm run build` läuft durch (geprüft, 592 ms, `users` chunk 3.36 kB)
- [x] Visuelle Verifikation Desktop + Mobile mit Mock-Daten (Toolbar/Table/Pagination/Hover/Disabled-State)
- [ ] Mit Admin-Account: Tab „Nutzer" lädt echte Nutzerliste innerhalb 1 s
- [ ] Tab-Wechsel während Loading: keine Konsolen-Fehler
- [ ] Filter wirkt nur auf aktuelle Seite (Tooltip auf Input)
- [ ] Pagination an leerer Folgepage: „Weiter" wird disabled

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)