### PR TITLE
feat(admin): phase 4 — game toggle (admin tab, home/nav/router gates)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,17 @@ const routes = {
 
 const GAME_ROUTES = new Set(['tetris', 'snake', 'dinos']);
 
-async function router() {
+// Serialize router() so two rapid hashchanges can't run in parallel and
+// race on `currentDestroy` / `app.innerHTML`. Each call queues onto the
+// previous; the hash-token bail then ensures only the latest navigation
+// actually mounts.
+let routerQueue = Promise.resolve();
+function router() {
+  routerQueue = routerQueue.then(_router, _router);
+  return routerQueue;
+}
+
+async function _router() {
   const hash = location.hash.replace('#/', '').split('?')[0] || '';
   const loader = routes[hash] ?? routes[''];
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 import { initNav } from './ui/nav.js';
 import { isSupabaseConfigured } from './api/supabase.js';
+import { getRouteAvailability } from './ui/game-availability.js';
+import { renderDisabledPage } from './ui/disabled-page.js';
 
 const app = document.getElementById('app');
 let currentDestroy = null;
@@ -12,6 +14,8 @@ const routes = {
   'admin':  () => import('./pages/admin/index.js'),
 };
 
+const GAME_ROUTES = new Set(['tetris', 'snake', 'dinos']);
+
 async function router() {
   const hash = location.hash.replace('#/', '').split('?')[0] || '';
   const loader = routes[hash] ?? routes[''];
@@ -23,7 +27,21 @@ async function router() {
   }
   app.innerHTML = '';
 
+  // Race-Schutz: bei Hash-Wechsel während eines awaits brechen wir ab
+  // und überlassen dem nächsten router()-Lauf das Rendering.
+  const routerHash = location.hash;
+
+  if (GAME_ROUTES.has(hash)) {
+    const avail = await getRouteAvailability(hash);
+    if (location.hash !== routerHash) return;
+    if (avail && !avail.enabled) {
+      currentDestroy = renderDisabledPage(app, hash, avail.disabled_message);
+      return;
+    }
+  }
+
   const mod = await loader();
+  if (location.hash !== routerHash) return;
   currentDestroy = mod.mount(app);
 }
 

--- a/src/pages/admin/games.js
+++ b/src/pages/admin/games.js
@@ -1,12 +1,130 @@
+import { getGameSettings, invalidateGameSettings, GAME_LABELS } from '../../ui/game-availability.js';
+import { refreshNavLinkAvailability } from '../../ui/nav.js';
+import { supabase } from '../../api/supabase.js';
+
 export function mount(container) {
+  let destroyed = false;
+
+  (async () => {
+    let settings;
+    try {
+      settings = await getGameSettings();
+    } catch (err) {
+      if (destroyed) return;
+      renderError(container, err);
+      return;
+    }
+    if (destroyed) return;
+    renderTable(container, settings);
+  })();
+
+  return () => { destroyed = true; };
+}
+
+function renderError(container, err) {
+  const p = document.createElement('p');
+  p.className = 'admin-error';
+  p.textContent = `Fehler beim Laden: ${err?.message ?? err}`;
+  container.appendChild(p);
+}
+
+function renderTable(container, settings) {
   const section = document.createElement('section');
   section.className = 'admin-tab admin-tab-games';
-  const p = document.createElement('p');
-  p.className = 'admin-placeholder-text';
-  p.textContent = 'Spiele-Verwaltung — folgt in Phase 4.';
-  section.appendChild(p);
+
+  const grid = document.createElement('div');
+  grid.className = 'admin-games';
+
+  for (const [game, label] of Object.entries(GAME_LABELS)) {
+    const row = buildRow(game, label, settings[game] ?? { enabled: true, disabled_message: null });
+    grid.appendChild(row);
+  }
+
+  section.appendChild(grid);
   container.appendChild(section);
-  return function destroy() {
-    // Phase-2-Platzhalter: noch nichts zu cleanen
+}
+
+function buildRow(game, label, { enabled, disabled_message }) {
+  const row = document.createElement('div');
+  row.className = 'admin-games-row';
+
+  // Label
+  const labelEl = document.createElement('span');
+  labelEl.className = 'admin-games-label';
+  labelEl.textContent = label;
+
+  // Checkbox
+  const toggleWrap = document.createElement('label');
+  toggleWrap.className = 'admin-games-toggle';
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = enabled;
+  const toggleText = document.createElement('span');
+  toggleText.textContent = 'aktiviert';
+  toggleWrap.append(checkbox, toggleText);
+
+  // Message input
+  const messageInput = document.createElement('input');
+  messageInput.type = 'text';
+  messageInput.className = 'admin-games-message';
+  messageInput.placeholder = 'Deaktivierungs-Nachricht (optional)';
+  messageInput.maxLength = 200;
+  messageInput.value = disabled_message ?? '';
+
+  // Save button
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'btn-ghost';
+  saveBtn.textContent = 'Speichern';
+
+  // Status
+  const statusEl = document.createElement('span');
+  statusEl.className = 'admin-games-status';
+
+  saveBtn.addEventListener('click', () => {
+    handleSave(game, checkbox.checked, messageInput.value, saveBtn, statusEl);
+  });
+
+  // Status zurücksetzen, sobald der User wieder editiert (Dirty-Flag)
+  const resetStatus = () => {
+    if (statusEl.textContent) {
+      statusEl.textContent = '';
+      statusEl.className = 'admin-games-status';
+    }
   };
+  checkbox.addEventListener('change', resetStatus);
+  messageInput.addEventListener('input', resetStatus);
+
+  row.append(labelEl, toggleWrap, messageInput, saveBtn, statusEl);
+  return row;
+}
+
+async function handleSave(game, enabled, message, saveBtn, statusEl) {
+  saveBtn.disabled = true;
+  statusEl.textContent = 'Speichere …';
+  statusEl.className = 'admin-games-status admin-games-status-loading';
+
+  // updated_by bewusst nicht aus dem Client gesetzt — gehört serverseitig
+  // (Trigger in einer späteren Migration). Bleibt NULL bis dahin.
+  const { error } = await supabase
+    .from('game_settings')
+    .update({
+      enabled,
+      disabled_message: (message ?? '').trim() || null,
+    })
+    .eq('game', game);
+
+  saveBtn.disabled = false;
+
+  if (error) {
+    statusEl.textContent = error.code === '42501'
+      ? 'Keine Admin-Berechtigung.'
+      : `Fehler: ${error.message}`;
+    statusEl.className = 'admin-games-status admin-games-status-error';
+    return;
+  }
+
+  invalidateGameSettings();
+  refreshNavLinkAvailability();
+  statusEl.textContent = 'Gespeichert ✓';
+  statusEl.className = 'admin-games-status admin-games-status-success';
 }

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,6 +1,9 @@
 import { renderLeaderboard } from '../ui/leaderboard.js';
+import { getRouteAvailability } from '../ui/game-availability.js';
 
 export function mount(container) {
+  let destroyed = false;
+
   container.innerHTML = `
     <div class="home-page">
       <header class="hero">
@@ -8,19 +11,19 @@ export function mount(container) {
         <p>Tetris, Snake & Dino-Evo — wähle dein Spiel</p>
       </header>
       <div class="game-cards">
-        <a href="#/tetris" class="game-card">
+        <a href="#/tetris" class="game-card" data-route="tetris">
           <div class="game-card-icon">🟦</div>
           <h2>Tetris</h2>
           <p>Klassischer Fallblock-Spaß</p>
           <span class="btn-primary">Spielen</span>
         </a>
-        <a href="#/snake" class="game-card">
+        <a href="#/snake" class="game-card" data-route="snake">
           <div class="game-card-icon">🐍</div>
           <h2>Snake</h2>
           <p>Schlange wachsen lassen</p>
           <span class="btn-primary">Spielen</span>
         </a>
-        <a href="#/dinos" class="game-card">
+        <a href="#/dinos" class="game-card" data-route="dinos">
           <div class="game-card-icon">🦖</div>
           <h2>Dino-Evo</h2>
           <p>Führe deine Herde durch die Generationen</p>
@@ -32,5 +35,27 @@ export function mount(container) {
 
   renderLeaderboard(document.getElementById('home-leaderboard'), 'tetris');
 
-  return function destroy() {};
+  // Async: mark disabled cards without blocking initial render
+  const cards = container.querySelectorAll('.game-card[data-route]');
+  cards.forEach(card => {
+    const route = card.dataset.route;
+    (async () => {
+      const avail = await getRouteAvailability(route);
+      if (destroyed) return;
+      if (!avail.enabled) {
+        card.classList.add('game-card--disabled');
+        if (avail.disabled_message) {
+          card.title = avail.disabled_message;
+          const msg = document.createElement('span');
+          msg.className = 'game-card-disabled-msg';
+          msg.textContent = avail.disabled_message;
+          card.appendChild(msg);
+        }
+      }
+    })();
+  });
+
+  return function destroy() {
+    destroyed = true;
+  };
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -881,3 +881,128 @@ dialog::backdrop {
   .admin-users-toolbar { flex-direction: column; align-items: stretch; }
   .admin-users-search  { flex: 1 1 auto; }
 }
+
+/* ===== Game-Card: deaktiviert ===== */
+.game-card--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  filter: grayscale(60%);
+}
+.game-card--disabled:hover {
+  border-color: var(--border-subtle);
+  transform: none;
+}
+
+.game-card-disabled-msg {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+/* ===== Nav-Link: deaktiviert ===== */
+.nav-links a.nav-link--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  text-decoration: line-through;
+}
+.nav-links a.nav-link--disabled:hover {
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+
+/* ===== Disabled-Page ===== */
+.disabled-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  padding: 3rem 1.5rem;
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+.disabled-page h1 { font-size: 1.8rem; }
+.disabled-page p  { color: var(--text-muted); }
+.disabled-page-btn {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity .15s;
+  text-decoration: none;
+}
+.disabled-page-btn:hover { opacity: 0.85; text-decoration: none; }
+
+/* ===== Admin – Games tab ===== */
+.admin-games {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin-games-row {
+  display: grid;
+  grid-template-columns: 200px auto 1fr auto auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+.admin-games-label {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.admin-games-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  white-space: nowrap;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.admin-games-message {
+  padding: 0.5rem 0.75rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+  min-width: 0;
+}
+.admin-games-message:focus { outline: 2px solid var(--accent); border-color: transparent; }
+
+.admin-games-status {
+  font-size: 0.85rem;
+  white-space: nowrap;
+  min-width: 7rem;
+  text-align: right;
+}
+.admin-games-status-loading { color: var(--text-muted); }
+.admin-games-status-success { color: var(--success); }
+.admin-games-status-error   { color: var(--danger); }
+
+@media (max-width: 640px) {
+  .admin-games-row {
+    grid-template-columns: 1fr;
+  }
+  .admin-games-status {
+    text-align: left;
+  }
+}

--- a/src/ui/disabled-page.js
+++ b/src/ui/disabled-page.js
@@ -1,0 +1,23 @@
+import { ROUTE_LABELS } from './game-availability.js';
+
+export function renderDisabledPage(container, route, disabledMessage) {
+  container.innerHTML = '';
+  const section = document.createElement('section');
+  section.className = 'disabled-page';
+
+  const h1 = document.createElement('h1');
+  h1.textContent = `${ROUTE_LABELS[route] ?? 'Dieses Spiel'} ist aktuell nicht verfügbar`;
+
+  const p = document.createElement('p');
+  p.textContent = disabledMessage || 'Das Spiel ist vorübergehend deaktiviert.';
+
+  const a = document.createElement('a');
+  a.href = '#/';
+  a.className = 'disabled-page-btn';
+  a.textContent = 'Zurück zur Startseite';
+
+  section.append(h1, p, a);
+  container.appendChild(section);
+
+  return function destroy() {};
+}

--- a/src/ui/game-availability.js
+++ b/src/ui/game-availability.js
@@ -1,0 +1,76 @@
+import { supabase } from '../api/supabase.js';
+
+export const ROUTE_TO_GAME_TYPES = {
+  tetris: ['tetris'],
+  snake:  ['snake'],
+  dinos:  ['dinos_realtime', 'dinos_turn'],
+};
+
+export const GAME_LABELS = {
+  tetris:         'Tetris',
+  snake:          'Snake',
+  dinos_realtime: 'Dino-Evo (Echtzeit)',
+  dinos_turn:     'Dino-Evo (Rundenbasiert)',
+};
+
+export const ROUTE_LABELS = {
+  tetris: 'Tetris',
+  snake:  'Snake',
+  dinos:  'Dino-Evo',
+};
+
+let cache = null;     // { data, expiresAt }
+let inflight = null;
+let cacheEpoch = 0;
+const TTL_MS = 30_000;
+
+// Bei DB-Down: fail-open (alle Games enabled), damit App nicht sperrt
+const FAIL_OPEN = {
+  tetris:         { enabled: true, disabled_message: null },
+  snake:          { enabled: true, disabled_message: null },
+  dinos_realtime: { enabled: true, disabled_message: null },
+  dinos_turn:     { enabled: true, disabled_message: null },
+};
+
+export async function getGameSettings() {
+  if (cache && Date.now() < cache.expiresAt) return cache.data;
+  if (inflight) return inflight;
+  const myEpoch = cacheEpoch;
+  inflight = (async () => {
+    try {
+      const { data, error } = await supabase
+        .from('game_settings')
+        .select('game, enabled, disabled_message');
+      if (error || !data) return FAIL_OPEN;
+      const map = Object.fromEntries(
+        data.map(r => [r.game, { enabled: r.enabled, disabled_message: r.disabled_message }])
+      );
+      // Stale-Write-Schutz: nur in Cache schreiben, wenn nicht zwischenzeitlich invalidated
+      if (myEpoch === cacheEpoch) {
+        cache = { data: map, expiresAt: Date.now() + TTL_MS };
+      }
+      return map;
+    } catch {
+      return FAIL_OPEN;
+    }
+  })();
+  try { return await inflight; }
+  finally { inflight = null; }
+}
+
+export async function getRouteAvailability(route) {
+  const settings = await getGameSettings();
+  const types = ROUTE_TO_GAME_TYPES[route] ?? [];
+  for (const t of types) {
+    if (!settings[t]?.enabled) {
+      return { enabled: false, disabled_message: settings[t]?.disabled_message ?? null };
+    }
+  }
+  return { enabled: true, disabled_message: null };
+}
+
+export function invalidateGameSettings() {
+  cache = null;
+  inflight = null;
+  cacheEpoch++;
+}

--- a/src/ui/nav.js
+++ b/src/ui/nav.js
@@ -1,5 +1,6 @@
 import { signOut, onAuthChange } from '../api/auth.js';
 import { supabase } from '../api/supabase.js';
+import { getRouteAvailability } from './game-availability.js';
 
 let unsubscribe = null;
 
@@ -8,9 +9,9 @@ export function initNav() {
   nav.innerHTML = `
     <div class="nav-brand"><a href="#/">🎮 GameHub</a></div>
     <div class="nav-links">
-      <a href="#/tetris">Tetris</a>
-      <a href="#/snake">Snake</a>
-      <a href="#/dinos">Dino-Evo</a>
+      <a href="#/tetris" data-route="tetris">Tetris</a>
+      <a href="#/snake" data-route="snake">Snake</a>
+      <a href="#/dinos" data-route="dinos">Dino-Evo</a>
     </div>
     <div class="nav-auth" id="nav-auth"></div>`;
 
@@ -35,4 +36,29 @@ export function initNav() {
 
   // Initial render from current session
   supabase.auth.getSession().then(({ data }) => renderAuthArea(data.session));
+
+  refreshNavLinkAvailability();
+}
+
+// Re-evaluates the disabled state of each game nav link against the current
+// game_settings cache. Safe to call repeatedly — exported so the admin Games
+// tab can refresh the nav after a toggle without a page reload.
+export function refreshNavLinkAvailability() {
+  const nav = document.getElementById('nav');
+  if (!nav) return;
+  const links = nav.querySelectorAll('.nav-links a[data-route]');
+  links.forEach(link => {
+    const route = link.dataset.route;
+    (async () => {
+      const avail = await getRouteAvailability(route);
+      if (avail.enabled) {
+        link.classList.remove('nav-link--disabled');
+        link.removeAttribute('title');
+      } else {
+        link.classList.add('nav-link--disabled');
+        if (avail.disabled_message) link.title = avail.disabled_message;
+        else link.removeAttribute('title');
+      }
+    })();
+  });
 }


### PR DESCRIPTION
## Summary

Phase 4 des Admin-Bereichs (Tracking-Issue #49): Spiele aktivieren/deaktivieren mit Auswirkung auf Home, Nav und Routing.

- `src/ui/game-availability.js` (neu): TTL-Cache 30 s über `game_settings`, Single-Flight gegen parallele DB-Reads, `cacheEpoch` gegen Stale-Writes, `try/catch` Fail-Open. Exports: `getGameSettings`, `getRouteAvailability(route)`, `invalidateGameSettings`.
- `src/ui/disabled-page.js` (neu): Minimal-Template für deaktivierte Routen — Heading, optionale Admin-Message, „Zurück zur Startseite".
- `src/pages/admin/games.js`: Phase-2-Platzhalter ersetzt. Vier Zeilen (eine pro `game_type`) mit Toggle, Message-Input, Save-Button und Status. Doppelklick-Schutz, Status reset bei Re-Edit. Triggert `invalidateGameSettings()` + `refreshNavLinkAvailability()` nach erfolgreichem Save.
- `src/main.js`: Router gated Game-Routen, rendert Disabled-Page bei `enabled === false`. Hash-Token-Check für Race-Schutz bei schnellen Nav-Wechseln.
- `src/pages/home.js` + `src/ui/nav.js`: Cards/Links bekommen `data-route`, async-Disable-Logik mit Cleanup-Flag. Nav exportiert `refreshNavLinkAvailability()`.
- CSS: alle neuen Klassen nutzen die semantischen Border-Tokens, keine Hardcoded-Farben.

## Architektur-Entscheidungen

1. **Laufende Spielsessions bleiben unangetastet.** Toggle ist Wartungs-Schalter, kein Sofort-Stopp.
2. **Score-Save während Disabled-Phase bleibt erlaubt** (keine Änderung an `scores`-Insert-Policy). Wenn das später anders gewünscht: neue Migration mit WITH-CHECK auf `game_settings.enabled`.
3. **Dinos-Route ist disabled wenn EINER der zwei Modes off ist.** Alternative wäre Mode-Picker-Gating im Spiel — zu komplex für aktuelle Phase.
4. **`updated_by` wird nicht clientseitig gesetzt** — gehört in einen DB-Trigger (separate Migration in Folge-Phase). Spalte bleibt bis dahin NULL.
5. **Nav-Refresh nach Toggle:** dedizierter Export `refreshNavLinkAvailability()` aus `nav.js`, vom Admin-Tab gerufen. Kein Custom-Event-Bus, kein Re-Init der gesamten Nav.

## Review-Findings (aus architect-Review) — alle adressiert

| Severity | Fix |
| -------- | --- |
| MED | `try/catch` um den Resolver in `game-availability.js` (Inflight-Reject-Schutz) |
| MED | Save-Button wird während Update disabled (Doppelklick-Schutz) |
| MED | Nav-Stale-State löst sich über `refreshNavLinkAvailability()` |
| LOW | Router-Race über `routerHash`-Token gegen Hash-Wechsel während `await` |
| LOW | Save-Status zurücksetzen bei Re-Edit |
| LOW | `updated_by` ganz entfernt (statt Client-Wert) |

## Test plan

- [x] `npm run build` läuft durch (geprüft, 618 ms)
- [x] Visueller Test: Default-State (alle Cards aktiv), Disabled-Card (Snake), Disabled-Page-Template, Admin-Games-Tab
- [ ] Mit echtem Admin-Account: in `#/admin` → Tab „Spiele" einen Toggle umschalten + Speichern → Status zeigt grünes ✓, Home/Nav reflektieren den State nach Tab-Wechsel
- [ ] Direkter Aufruf einer deaktivierten Route zeigt Disabled-Page mit der gespeicherten Message
- [ ] Re-Aktivieren propagiert nach TTL (30 s) bzw. sofort über `refreshNavLinkAvailability`
- [ ] Laufende Spielsession wird durch Toggle NICHT abgebrochen

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)