### PR TITLE
feat(admin): phase 5 — stats tab with KPIs, stacked chart, top players

### DIFF
--- a/src/pages/admin/stats-chart.js
+++ b/src/pages/admin/stats-chart.js
@@ -1,0 +1,223 @@
+// Pure helpers
+
+export function niceMax(raw) {
+  if (raw <= 0) return 5;
+  const steps = [5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000];
+  for (const s of steps) {
+    if (s >= raw) return s;
+  }
+  // Beyond 50000: round up to next multiple of 10000
+  return Math.ceil(raw / 10000) * 10000;
+}
+
+export function transformLongToWide(rows, days, gameTypes) {
+  // rows: [{ day: '2026-05-14', game: 'tetris', scores: 3, ... }, ...]   (from admin_stats_daily_fn)
+  // days: ['2026-04-15', ..., '2026-05-14'] ascending
+  // gameTypes: ['tetris', 'snake', ...]
+  // returns: { tetris: [0, 3, ...], snake: [...], ... }
+  const map = {};
+  for (const row of rows) {
+    // RPC liefert `day` als Date-Object (in JS-Land typisch als ISO-String)
+    const dayKey = typeof row.day === 'string' ? row.day : new Date(row.day).toISOString().slice(0, 10);
+    const key = `${dayKey}|${row.game}`;
+    map[key] = Number(row.scores ?? 0);
+  }
+  const result = {};
+  for (const gt of gameTypes) {
+    result[gt] = days.map(d => map[`${d}|${gt}`] ?? 0);
+  }
+  return result;
+}
+
+export function formatGermanShortDate(iso) {
+  // '2026-05-14' → '14.05.'
+  const [, m, d] = iso.split('-');
+  return `${d}.${m}.`;
+}
+
+export function createStackedLineChart({ canvas, days, series, gameOrder, colors }) {
+  const PAD_TOP = 20;
+  const PAD_RIGHT = 12;
+  const PAD_BOTTOM = 32;
+  const PAD_LEFT = 44;
+  const GRID_LINES = 5;
+
+  function cssVar(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  // Cached size, set by resizeCanvas() and re-used by every drawChart().
+  // Resize läuft NUR bei render() (ResizeObserver / initial Mount), nicht bei jedem Hover.
+  let cachedW = 0;
+  let cachedH = 0;
+
+  function resizeCanvas() {
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    const ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    cachedW = rect.width;
+    cachedH = rect.height;
+  }
+
+  function drawChart(hoverX) {
+    const ctx = canvas.getContext('2d');
+    const W = cachedW;
+    const H = cachedH;
+    if (W === 0 || H === 0) return;
+    ctx.clearRect(0, 0, W, H);
+    const chartW = W - PAD_LEFT - PAD_RIGHT;
+    const chartH = H - PAD_TOP - PAD_BOTTOM;
+
+    const colorBorderSubtle = cssVar('--border-subtle');
+    const colorTextMuted = cssVar('--text-muted');
+
+    // Compute per-day totals for Y max
+    const n = days.length;
+    const totals = Array.from({ length: n }, (_, i) =>
+      gameOrder.reduce((sum, g) => sum + (series[g]?.[i] ?? 0), 0)
+    );
+    const rawMax = n === 0 ? 0 : Math.max(...totals);
+    const yMax = niceMax(rawMax);
+
+    // Helpers: data → pixel
+    function xOf(i) {
+      if (n <= 1) return PAD_LEFT + chartW / 2;
+      return PAD_LEFT + (i / (n - 1)) * chartW;
+    }
+    function yOf(val) {
+      return PAD_TOP + chartH - (val / yMax) * chartH;
+    }
+
+    // Grid lines + Y labels
+    ctx.strokeStyle = colorBorderSubtle;
+    ctx.fillStyle = colorTextMuted;
+    ctx.font = '11px sans-serif';
+    ctx.textAlign = 'right';
+    ctx.lineWidth = 1;
+    for (let g = 0; g <= GRID_LINES; g++) {
+      const val = (g / GRID_LINES) * yMax;
+      const py = yOf(val);
+      ctx.beginPath();
+      ctx.moveTo(PAD_LEFT, py);
+      ctx.lineTo(PAD_LEFT + chartW, py);
+      ctx.stroke();
+      ctx.fillText(String(Math.round(val)), PAD_LEFT - 4, py + 4);
+    }
+
+    // X-axis labels: first, every 5 days, last
+    ctx.textAlign = 'center';
+    if (n > 0) {
+      const labelIndices = new Set([0, n - 1]);
+      for (let i = 0; i < n; i++) {
+        if (i % 5 === 0) labelIndices.add(i);
+      }
+      for (const i of labelIndices) {
+        const px = xOf(i);
+        ctx.fillText(formatGermanShortDate(days[i]), px, PAD_TOP + chartH + 18);
+      }
+    }
+
+    // Empty-data guard
+    const isEmpty = n === 0 || totals.every(t => t === 0);
+
+    if (isEmpty) {
+      ctx.fillStyle = colorTextMuted;
+      ctx.textAlign = 'center';
+      ctx.font = '14px sans-serif';
+      ctx.fillText('Keine Daten in den letzten 30 Tagen', PAD_LEFT + chartW / 2, PAD_TOP + chartH / 2);
+      return;
+    }
+
+    // Stacked areas + lines
+    for (let gi = 0; gi < gameOrder.length; gi++) {
+      const game = gameOrder[gi];
+      const color = colors[game] ?? '#888';
+
+      // Compute cumulative stacked Y for this layer and all layers below
+      const cumulTop = Array.from({ length: n }, (_, i) =>
+        gameOrder.slice(0, gi + 1).reduce((sum, g) => sum + (series[g]?.[i] ?? 0), 0)
+      );
+      const cumulBot = Array.from({ length: n }, (_, i) =>
+        gameOrder.slice(0, gi).reduce((sum, g) => sum + (series[g]?.[i] ?? 0), 0)
+      );
+
+      // Filled area
+      ctx.beginPath();
+      // top edge left→right
+      for (let i = 0; i < n; i++) {
+        const px = xOf(i);
+        const py = yOf(cumulTop[i]);
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      // bottom edge right→left
+      for (let i = n - 1; i >= 0; i--) {
+        ctx.lineTo(xOf(i), yOf(cumulBot[i]));
+      }
+      ctx.closePath();
+      ctx.globalAlpha = 0.25;
+      ctx.fillStyle = color;
+      ctx.fill();
+      ctx.globalAlpha = 1;
+
+      // Stroke (top edge only)
+      ctx.beginPath();
+      for (let i = 0; i < n; i++) {
+        const px = xOf(i);
+        const py = yOf(cumulTop[i]);
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+
+    // Hover indicator
+    if (hoverX !== null && n > 0) {
+      // Snap to nearest day
+      let best = 0;
+      let bestDist = Infinity;
+      for (let i = 0; i < n; i++) {
+        const dist = Math.abs(xOf(i) - hoverX);
+        if (dist < bestDist) { bestDist = dist; best = i; }
+      }
+      const px = xOf(best);
+
+      ctx.strokeStyle = colorTextMuted;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 3]);
+      ctx.beginPath();
+      ctx.moveTo(px, PAD_TOP);
+      ctx.lineTo(px, PAD_TOP + chartH);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      const total = totals[best];
+      const label = `Σ ${total.toLocaleString('de-DE')} am ${formatGermanShortDate(days[best])}`;
+      ctx.font = '12px sans-serif';
+      ctx.textAlign = 'right';
+      ctx.fillStyle = colorTextMuted;
+      ctx.fillText(label, PAD_LEFT + chartW, PAD_TOP + 14);
+    }
+  }
+
+  let currentHoverX = null;
+
+  return {
+    render() {
+      resizeCanvas();
+      drawChart(currentHoverX);
+    },
+    setHover(x) {
+      currentHoverX = x;
+      drawChart(currentHoverX);
+    },
+    destroy() {
+      // no-op: mouse/resize listeners registered by caller
+    },
+  };
+}

--- a/src/pages/admin/stats.js
+++ b/src/pages/admin/stats.js
@@ -1,12 +1,351 @@
+import { statsActiveUsers, statsDaily, topPlayers } from '../../api/admin.js';
+import {
+  createStackedLineChart,
+  transformLongToWide,
+} from './stats-chart.js';
+
+const GAME_ORDER = ['tetris', 'snake', 'dinos_realtime', 'dinos_turn'];
+const GAME_LABELS = {
+  tetris: 'Tetris',
+  snake: 'Snake',
+  dinos_realtime: 'Dinos (Echtzeit)',
+  dinos_turn: 'Dinos (Züge)',
+};
+// CSS variable names for chart colors — read at render time
+const GAME_COLOR_VARS = {
+  tetris: '--accent',
+  snake: '--accent2',
+  dinos_realtime: '--danger',
+  dinos_turn: '--text-muted',
+};
+
+function formatDate(val) {
+  if (!val) return '—';
+  return new Date(val).toLocaleDateString('de-DE');
+}
+
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+// Generate an array of YYYY-MM-DD strings for the last `n` days (ascending, ending today)
+function lastNDays(n) {
+  // Pure UTC: DB-Seite (date_trunc + CURRENT_DATE) arbeitet ebenfalls UTC.
+  // Lokale Date-Arithmetik würde spät abends in CEST einen falschen Tagesschlüssel liefern.
+  const days = [];
+  const now = new Date();
+  const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(todayUTC);
+    d.setUTCDate(todayUTC.getUTCDate() - i);
+    days.push(d.toISOString().slice(0, 10));
+  }
+  return days;
+}
+
 export function mount(container) {
+  let active = true;
+  let chart = null;
+  let resizeObserver = null;
+  const tabListeners = []; // { el, type, fn }
+  let chartMouseMove = null;
+  let chartMouseLeave = null;
+  let canvasEl = null;
+  let requestSeq = 0; // race guard for top-player tab clicks
+
+  // ---- Build skeleton DOM ----
   const section = document.createElement('section');
-  section.className = 'admin-tab admin-tab-stats';
-  const p = document.createElement('p');
-  p.className = 'admin-placeholder-text';
-  p.textContent = 'Statistiken — folgen in Phase 5.';
-  section.appendChild(p);
+  section.className = 'admin-stats';
+
+  // KPI row
+  const kpiRow = document.createElement('div');
+  kpiRow.className = 'admin-stats-kpis';
+
+  const kpiKeys = [
+    { key: 'dau', label: 'DAU' },
+    { key: 'wau', label: 'WAU' },
+    { key: 'mau', label: 'MAU' },
+  ];
+  const kpiValueEls = {};
+  for (const { key, label } of kpiKeys) {
+    const card = document.createElement('div');
+    card.className = 'admin-stats-kpi';
+
+    const lbl = document.createElement('span');
+    lbl.className = 'admin-stats-kpi-label';
+    lbl.textContent = label;
+
+    const val = document.createElement('span');
+    val.className = 'admin-stats-kpi-value';
+    val.textContent = '…';
+
+    card.appendChild(lbl);
+    card.appendChild(val);
+    kpiRow.appendChild(card);
+    kpiValueEls[key] = val;
+  }
+
+  // Chart section
+  const chartSection = document.createElement('div');
+  chartSection.className = 'admin-stats-section';
+
+  const chartHeader = document.createElement('div');
+  chartHeader.className = 'admin-stats-section-header';
+  const chartTitle = document.createElement('h2');
+  chartTitle.textContent = 'Scores pro Tag (letzte 30 Tage)';
+  chartHeader.appendChild(chartTitle);
+
+  canvasEl = document.createElement('canvas');
+  canvasEl.className = 'admin-stats-chart-canvas';
+
+  const legend = document.createElement('div');
+  legend.className = 'admin-stats-chart-legend';
+  for (const game of GAME_ORDER) {
+    const item = document.createElement('span');
+    item.className = 'admin-stats-legend-item';
+
+    const dot = document.createElement('i');
+    dot.className = 'dot';
+    // color set after cssVar is readable (defer to after DOM insert)
+    dot.dataset.colorVar = GAME_COLOR_VARS[game];
+
+    const lbl = document.createElement('span');
+    lbl.textContent = GAME_LABELS[game];
+
+    item.appendChild(dot);
+    item.appendChild(lbl);
+    legend.appendChild(item);
+  }
+
+  chartSection.appendChild(chartHeader);
+  chartSection.appendChild(canvasEl);
+  chartSection.appendChild(legend);
+
+  // Top-players section
+  const topSection = document.createElement('div');
+  topSection.className = 'admin-stats-section';
+
+  const topHeader = document.createElement('div');
+  topHeader.className = 'admin-stats-section-header';
+
+  const topTitle = document.createElement('h2');
+  topTitle.textContent = 'Top-Spieler';
+
+  const tabList = document.createElement('div');
+  tabList.className = 'admin-stats-top-tabs';
+  tabList.setAttribute('role', 'tablist');
+
+  const tabEls = {};
+  for (const game of GAME_ORDER) {
+    const btn = document.createElement('button');
+    btn.className = 'admin-stats-top-tab' + (game === 'tetris' ? ' active' : '');
+    btn.textContent = GAME_LABELS[game];
+    btn.dataset.game = game;
+    btn.setAttribute('role', 'tab');
+    tabList.appendChild(btn);
+    tabEls[game] = btn;
+  }
+
+  topHeader.appendChild(topTitle);
+  topHeader.appendChild(tabList);
+
+  const tableWrap = document.createElement('div');
+  tableWrap.className = 'admin-table-wrap';
+
+  const table = document.createElement('table');
+  table.className = 'admin-table';
+
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  for (const label of ['#', 'Name', 'Score', 'Datum']) {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  }
+  thead.appendChild(headRow);
+
+  const tbody = document.createElement('tbody');
+  table.appendChild(thead);
+  table.appendChild(tbody);
+  tableWrap.appendChild(table);
+
+  topSection.appendChild(topHeader);
+  topSection.appendChild(tableWrap);
+
+  section.appendChild(kpiRow);
+  section.appendChild(chartSection);
+  section.appendChild(topSection);
   container.appendChild(section);
+
+  // Now that DOM is inserted, set legend dot colors from CSS vars
+  for (const dot of legend.querySelectorAll('.dot')) {
+    dot.style.background = cssVar(dot.dataset.colorVar);
+  }
+
+  // ---- Helpers ----
+  function setTbodyMessage(text, cls) {
+    tbody.textContent = '';
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 4;
+    td.className = cls;
+    td.textContent = text;
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  }
+
+  function buildTopRow(rank, entry) {
+    const tr = document.createElement('tr');
+    const cells = [
+      String(rank),
+      entry.display_name ?? '—',
+      (entry.score ?? 0).toLocaleString('de-DE'),
+      formatDate(entry.created_at),
+    ];
+    for (const text of cells) {
+      const td = document.createElement('td');
+      td.textContent = text;
+      tr.appendChild(td);
+    }
+    return tr;
+  }
+
+  function renderTopRows(data) {
+    tbody.textContent = '';
+    if (!data || data.length === 0) {
+      setTbodyMessage('Keine Einträge vorhanden.', 'admin-empty');
+      return;
+    }
+    data.forEach((entry, idx) => {
+      tbody.appendChild(buildTopRow(idx + 1, entry));
+    });
+  }
+
+  async function loadTopPlayers(game) {
+    const seq = ++requestSeq;
+    setTbodyMessage('Lade …', 'admin-loading');
+    let data;
+    try {
+      data = await topPlayers(game, 10);
+    } catch (err) {
+      if (!active || requestSeq !== seq) return;
+      setTbodyMessage(`Fehler: ${err.message}`, 'admin-error');
+      return;
+    }
+    if (!active || requestSeq !== seq) return;
+    renderTopRows(data);
+  }
+
+  // Tab click handler
+  function onTabClick(e) {
+    const btn = e.currentTarget;
+    const game = btn.dataset.game;
+    for (const g of GAME_ORDER) {
+      tabEls[g].classList.toggle('active', g === game);
+    }
+    loadTopPlayers(game);
+  }
+
+  for (const game of GAME_ORDER) {
+    const fn = onTabClick;
+    tabEls[game].addEventListener('click', fn);
+    tabListeners.push({ el: tabEls[game], type: 'click', fn });
+  }
+
+  // Chart mouse handlers
+  chartMouseMove = (e) => { if (chart) chart.setHover(e.offsetX); };
+  chartMouseLeave = () => { if (chart) chart.setHover(null); };
+  canvasEl.addEventListener('mousemove', chartMouseMove);
+  canvasEl.addEventListener('mouseleave', chartMouseLeave);
+
+  // Initial loading states
+  setTbodyMessage('Lade …', 'admin-loading');
+
+  // Draw empty chart as placeholder while loading
+  {
+    const placeholderColors = {};
+    for (const g of GAME_ORDER) placeholderColors[g] = cssVar(GAME_COLOR_VARS[g]);
+    chart = createStackedLineChart({
+      canvas: canvasEl,
+      days: [],
+      series: {},
+      gameOrder: GAME_ORDER,
+      colors: placeholderColors,
+    });
+    chart.render();
+  }
+
+  // ResizeObserver
+  resizeObserver = new ResizeObserver(() => {
+    if (chart) {
+      chart.render();
+    }
+  });
+  resizeObserver.observe(canvasEl);
+
+  // ---- Parallel data fetch ----
+  Promise.allSettled([
+    statsActiveUsers(),
+    statsDaily(30),
+    topPlayers('tetris', 10),
+  ]).then(([kpiResult, dailyResult, topResult]) => {
+    if (!active) return;
+
+    // KPIs
+    if (kpiResult.status === 'fulfilled') {
+      const d = kpiResult.value;
+      kpiValueEls.dau.textContent = d?.dau != null ? Number(d.dau).toLocaleString('de-DE') : '—';
+      kpiValueEls.wau.textContent = d?.wau != null ? Number(d.wau).toLocaleString('de-DE') : '—';
+      kpiValueEls.mau.textContent = d?.mau != null ? Number(d.mau).toLocaleString('de-DE') : '—';
+    } else {
+      for (const key of ['dau', 'wau', 'mau']) kpiValueEls[key].textContent = 'Fehler';
+    }
+
+    // Chart
+    if (dailyResult.status === 'fulfilled') {
+      const rows = dailyResult.value;
+      const days = lastNDays(30);
+      const colors = {};
+      for (const g of GAME_ORDER) colors[g] = cssVar(GAME_COLOR_VARS[g]);
+      const series = transformLongToWide(rows, days, GAME_ORDER);
+
+      if (chart) chart.destroy();
+      chart = createStackedLineChart({ canvas: canvasEl, days, series, gameOrder: GAME_ORDER, colors });
+      chart.render();
+    } else {
+      // Show error inside chart area
+      const errBox = document.createElement('p');
+      errBox.className = 'admin-error';
+      errBox.textContent = `Chart-Fehler: ${dailyResult.reason?.message ?? 'Unbekannter Fehler'}`;
+      chartSection.insertBefore(errBox, canvasEl);
+    }
+
+    // Top players (tetris preloaded)
+    if (topResult.status === 'fulfilled') {
+      renderTopRows(topResult.value);
+    } else {
+      setTbodyMessage(`Fehler: ${topResult.reason?.message ?? 'Unbekannter Fehler'}`, 'admin-error');
+    }
+  });
+
   return function destroy() {
-    // Phase-2-Platzhalter: noch nichts zu cleanen
+    active = false;
+
+    for (const { el, type, fn } of tabListeners) {
+      el.removeEventListener(type, fn);
+    }
+
+    if (chartMouseMove) canvasEl.removeEventListener('mousemove', chartMouseMove);
+    if (chartMouseLeave) canvasEl.removeEventListener('mouseleave', chartMouseLeave);
+
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+      resizeObserver = null;
+    }
+
+    if (chart) {
+      chart.destroy();
+      chart = null;
+    }
   };
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -998,11 +998,95 @@ dialog::backdrop {
 .admin-games-status-success { color: var(--success); }
 .admin-games-status-error   { color: var(--danger); }
 
+/* ===== Admin – Stats tab ===== */
+.admin-stats { display: flex; flex-direction: column; gap: 2rem; }
+
+.admin-stats-kpis { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+
+.admin-stats-kpi {
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+}
+
+.admin-stats-kpi-label {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.admin-stats-kpi-value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-top: 0.25rem;
+}
+
+.admin-stats-section {
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+}
+
+.admin-stats-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.admin-stats-section h2 { margin: 0; font-size: 1rem; color: var(--text); }
+
+.admin-stats-chart-canvas { display: block; width: 100%; height: 280px; }
+
+.admin-stats-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.admin-stats-legend-item { display: inline-flex; align-items: center; gap: 0.4rem; }
+
+.admin-stats-legend-item .dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.admin-stats-top-tabs { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+
+.admin-stats-top-tab {
+  background: transparent;
+  border: none;
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font: inherit;
+  cursor: pointer;
+}
+
+.admin-stats-top-tab.active { background: var(--surface2); color: var(--accent); }
+
+.admin-stats-empty { color: var(--text-muted); padding: 2rem; text-align: center; }
+
 @media (max-width: 640px) {
-  .admin-games-row {
-    grid-template-columns: 1fr;
-  }
-  .admin-games-status {
-    text-align: left;
-  }
+  .admin-games-row { grid-template-columns: 1fr; }
+  .admin-games-status { text-align: left; }
+
+  .admin-stats-kpis { grid-template-columns: 1fr; }
+  .admin-stats-kpi-value { font-size: 1.5rem; }
+  .admin-stats-chart-canvas { height: 220px; }
+  .admin-stats-top-tabs { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .admin-stats-top-tab { white-space: nowrap; }
 }


### PR DESCRIPTION
## Summary

Phase 5 des Admin-Bereichs (Tracking-Issue #49): Stats-Tab mit drei Sektionen.

- **KPI-Karten** (DAU/WAU/MAU) mit deutscher Zahlenformatierung.
- **Gestapelter Line-Chart**, letzte 30 Tage Scores pro Spiel, Vanilla Canvas, DPR-aware. Mit Hover-Snap (senkrechte Linie + Tagesgesamt). Resize läuft nur in `render()`, nicht in `setHover()` — kein Memory-Churn bei Maus-Move.
- **Top-Spieler-Tabelle** pro Spiel über vier Tab-Selektor-Buttons. `requestSeq`-Token gegen Race bei schnellen Tab-Wechseln.
- Parallel `Promise.allSettled` für die drei RPCs aus Phase 1; Partial-Render bei Sektion-Failure.

## Architektur-Entscheidungen

- Chart split in `stats.js` (Orchestrator + Daten) und `stats-chart.js` (reine Canvas-Factory + pure Helper). Helper testbar — Test-Scope bewusst nicht erweitert (CLAUDE.md verbietet stille Vitest-Erweiterung).
- Farben pro Spiel über CSS-Custom-Properties (`--accent`, `--accent2`, `--danger`, `--text-muted`).
- `lastNDays()` nutzt **reine UTC-Arithmetik** — passt zu Postgres' `date_trunc('day', created_at)` mit `timestamptz` (UTC-Bucket). Lokale Date-Arithmetik produzierte sonst spät abends in CEST eine Lücke beim letzten Tagesschlüssel.

## Review-Findings (architect) — alle adressiert

| Severity | Fix |
| -------- | --- |
| MED | Canvas-Resize nur noch in `render()`, nicht in `setHover()` — kein DPR-Backing-Store-Realloc bei 60 Hz Hover |
| MED | UTC-Datum-Bug in `lastNDays()` — `setUTCDate` + `Date.UTC()` |
| LOW | Ungenutzter `formatGermanShortDate`-Import entfernt |

Zusätzliche Bugfixes auf Basis Selbst-Review der Develop-Phase:
- `transformLongToWide` nutzt die korrekten RPC-Feldnamen `game` und `scores` (statt `game_type`/`count`).
- KPI-Werte werden via `Number(...).toLocaleString('de-DE')` formatiert.

## Test plan

- [x] `npm run build` läuft durch (geprüft, 606 ms; stats-Chunk 8.21 kB)
- [x] Visueller Test mit Mock-Daten Desktop (Chart, KPIs, Top-Spieler)
- [ ] Mit echtem Admin-Account: in `#/admin` → Tab „Statistiken" — KPIs zeigen reelle Zahlen, Chart rendert mit echten DB-Daten
- [ ] Tab-Wechsel im Top-Spieler: Tabelle wechselt korrekt, kein Race
- [ ] Tab-Wechsel weg vom Stats-Tab während Loading: keine Konsolen-Fehler

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)