### PR TITLE
feat(admin): phase 9 — maintenance banner, footer, datenschutz page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,16 +2,19 @@ import { initNav } from './ui/nav.js';
 import { isSupabaseConfigured } from './api/supabase.js';
 import { getRouteAvailability } from './ui/game-availability.js';
 import { renderDisabledPage } from './ui/disabled-page.js';
+import { initMaintenanceBanner } from './ui/maintenance-banner.js';
+import { initFooter } from './ui/footer.js';
 
 const app = document.getElementById('app');
 let currentDestroy = null;
 
 const routes = {
-  '':       () => import('./pages/home.js'),
-  'tetris': () => import('./pages/tetris.js'),
-  'snake':  () => import('./pages/snake.js'),
-  'dinos':  () => import('./pages/dinos.js'),
-  'admin':  () => import('./pages/admin/index.js'),
+  '':            () => import('./pages/home.js'),
+  'tetris':      () => import('./pages/tetris.js'),
+  'snake':       () => import('./pages/snake.js'),
+  'dinos':       () => import('./pages/dinos.js'),
+  'admin':       () => import('./pages/admin/index.js'),
+  'datenschutz': () => import('./pages/datenschutz.js'),
 };
 
 const GAME_ROUTES = new Set(['tetris', 'snake', 'dinos']);
@@ -84,6 +87,8 @@ async function init() {
   }
 
   initNav();
+  initMaintenanceBanner(document.body);
+  initFooter(document.body);
   window.addEventListener('hashchange', router);
   await router();
 }

--- a/src/pages/admin/announcements.js
+++ b/src/pages/admin/announcements.js
@@ -1,12 +1,290 @@
+import { supabase } from '../../api/supabase.js';
+import { refreshMaintenanceBanner } from '../../ui/maintenance-banner.js';
+
 export function mount(container) {
+  let destroyed = false;
+  const cleanups = [];
+
   const section = document.createElement('section');
   section.className = 'admin-tab admin-tab-announcements';
-  const p = document.createElement('p');
-  p.className = 'admin-placeholder-text';
-  p.textContent = 'Banner-Verwaltung — folgt in Phase 9.';
-  section.appendChild(p);
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'admin-announcements';
+
+  // ── Create form ──────────────────────────────────────────────────────────
+
+  const createForm = document.createElement('div');
+  createForm.className = 'admin-announcements-row';
+
+  const newTextarea = document.createElement('textarea');
+  newTextarea.placeholder = 'Nachricht (max. 500 Zeichen)';
+  newTextarea.maxLength = 500;
+
+  const newSeverity = document.createElement('select');
+  for (const [val, label] of [['info', 'Info'], ['warning', 'Warnung'], ['critical', 'Kritisch']]) {
+    const opt = document.createElement('option');
+    opt.value = val;
+    opt.textContent = label;
+    newSeverity.appendChild(opt);
+  }
+
+  const newActiveLabel = document.createElement('label');
+  const newActiveCheck = document.createElement('input');
+  newActiveCheck.type = 'checkbox';
+  newActiveCheck.checked = true;
+  const newActiveText = document.createElement('span');
+  newActiveText.textContent = 'Aktiv';
+  newActiveLabel.append(newActiveCheck, newActiveText);
+
+  const newExpires = document.createElement('input');
+  newExpires.type = 'datetime-local';
+  newExpires.title = 'Ablaufdatum (optional)';
+
+  const createBtn = document.createElement('button');
+  createBtn.className = 'btn-primary';
+  createBtn.textContent = 'Anlegen';
+
+  const createStatus = document.createElement('span');
+  createStatus.className = 'admin-games-status';
+
+  const createHandler = async () => {
+    const message = newTextarea.value.trim();
+    if (!message) {
+      createStatus.textContent = 'Nachricht darf nicht leer sein.';
+      createStatus.className = 'admin-games-status admin-games-status-error';
+      return;
+    }
+    createBtn.disabled = true;
+    createStatus.textContent = 'Speichere …';
+    createStatus.className = 'admin-games-status admin-games-status-loading';
+
+    const payload = {
+      message,
+      severity: newSeverity.value,
+      active: newActiveCheck.checked,
+      expires_at: newExpires.value ? new Date(newExpires.value).toISOString() : null,
+      // created_by intentionally NOT sent — defense-in-depth, analog games.js
+    };
+
+    const { data, error } = await supabase
+      .from('site_announcements')
+      .insert(payload)
+      .select()
+      .single();
+
+    createBtn.disabled = false;
+
+    if (error) {
+      createStatus.textContent = error.code === '42501'
+        ? 'Keine Admin-Berechtigung.'
+        : `Fehler: ${error.message}`;
+      createStatus.className = 'admin-games-status admin-games-status-error';
+      return;
+    }
+
+    createStatus.textContent = 'Angelegt ✓';
+    createStatus.className = 'admin-games-status admin-games-status-success';
+    newTextarea.value = '';
+    newExpires.value = '';
+    newActiveCheck.checked = true;
+
+    await refreshMaintenanceBanner();
+    if (!destroyed) appendRow(list, data);
+  };
+  createBtn.addEventListener('click', createHandler);
+  cleanups.push(() => createBtn.removeEventListener('click', createHandler));
+
+  const resetCreate = () => {
+    if (createStatus.textContent) {
+      createStatus.textContent = '';
+      createStatus.className = 'admin-games-status';
+    }
+  };
+  newTextarea.addEventListener('input', resetCreate);
+  cleanups.push(() => newTextarea.removeEventListener('input', resetCreate));
+
+  createForm.append(newTextarea, newSeverity, newActiveLabel, newExpires, createBtn, createStatus);
+
+  // ── List ─────────────────────────────────────────────────────────────────
+
+  const list = document.createElement('div');
+  list.className = 'admin-announcements-list';
+
+  wrapper.append(createForm, list);
+  section.appendChild(wrapper);
   container.appendChild(section);
+
+  // ── Load ─────────────────────────────────────────────────────────────────
+
+  (async () => {
+    const loadingEl = document.createElement('p');
+    loadingEl.className = 'admin-loading';
+    loadingEl.textContent = 'Lade Ankündigungen …';
+    list.appendChild(loadingEl);
+
+    const { data, error } = await supabase
+      .from('site_announcements')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (destroyed) return;
+    loadingEl.remove();
+
+    if (error) {
+      const errEl = document.createElement('p');
+      errEl.className = 'admin-error';
+      errEl.textContent = error.code === '42501'
+        ? 'Keine Admin-Berechtigung.'
+        : `Fehler: ${error.message}`;
+      list.appendChild(errEl);
+      return;
+    }
+
+    if (!data || data.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'admin-empty';
+      empty.textContent = 'Keine Ankündigungen vorhanden.';
+      list.appendChild(empty);
+      return;
+    }
+
+    for (const a of data) appendRow(list, a);
+  })();
+
+  function appendRow(listEl, a) {
+    const row = document.createElement('div');
+    row.className = 'admin-announcements-row';
+    row.dataset.id = String(a.id);
+
+    const textarea = document.createElement('textarea');
+    textarea.value = a.message;
+    textarea.maxLength = 500;
+
+    const severitySelect = document.createElement('select');
+    for (const [val, label] of [['info', 'Info'], ['warning', 'Warnung'], ['critical', 'Kritisch']]) {
+      const opt = document.createElement('option');
+      opt.value = val;
+      opt.textContent = label;
+      if (val === a.severity) opt.selected = true;
+      severitySelect.appendChild(opt);
+    }
+
+    const activeLabel = document.createElement('label');
+    const activeCheck = document.createElement('input');
+    activeCheck.type = 'checkbox';
+    activeCheck.checked = a.active;
+    const activeText = document.createElement('span');
+    activeText.textContent = 'Aktiv';
+    activeLabel.append(activeCheck, activeText);
+
+    const expiresInput = document.createElement('input');
+    expiresInput.type = 'datetime-local';
+    if (a.expires_at) {
+      expiresInput.value = new Date(a.expires_at).toISOString().slice(0, 16);
+    }
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'btn-ghost';
+    saveBtn.textContent = 'Speichern';
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'btn-ghost';
+    deleteBtn.style.color = 'var(--danger)';
+    deleteBtn.textContent = 'Löschen';
+
+    const statusEl = document.createElement('span');
+    statusEl.className = 'admin-games-status';
+
+    const resetStatus = () => {
+      if (statusEl.textContent) {
+        statusEl.textContent = '';
+        statusEl.className = 'admin-games-status';
+      }
+    };
+    textarea.addEventListener('input', resetStatus);
+    severitySelect.addEventListener('change', resetStatus);
+    activeCheck.addEventListener('change', resetStatus);
+    expiresInput.addEventListener('change', resetStatus);
+
+    const saveHandler = async () => {
+      const message = textarea.value.trim();
+      if (!message) {
+        statusEl.textContent = 'Nachricht darf nicht leer sein.';
+        statusEl.className = 'admin-games-status admin-games-status-error';
+        return;
+      }
+      saveBtn.disabled = true;
+      statusEl.textContent = 'Speichere …';
+      statusEl.className = 'admin-games-status admin-games-status-loading';
+
+      const { error } = await supabase
+        .from('site_announcements')
+        .update({
+          message,
+          severity: severitySelect.value,
+          active: activeCheck.checked,
+          expires_at: expiresInput.value ? new Date(expiresInput.value).toISOString() : null,
+        })
+        .eq('id', a.id);
+
+      saveBtn.disabled = false;
+
+      if (error) {
+        statusEl.textContent = error.code === '42501'
+          ? 'Keine Admin-Berechtigung.'
+          : `Fehler: ${error.message}`;
+        statusEl.className = 'admin-games-status admin-games-status-error';
+        return;
+      }
+
+      statusEl.textContent = 'Gespeichert ✓';
+      statusEl.className = 'admin-games-status admin-games-status-success';
+      await refreshMaintenanceBanner();
+    };
+    saveBtn.addEventListener('click', saveHandler);
+
+    const deleteHandler = async () => {
+      if (!confirm('Wirklich löschen?')) return;
+      deleteBtn.disabled = true;
+      statusEl.textContent = 'Lösche …';
+      statusEl.className = 'admin-games-status admin-games-status-loading';
+
+      const { error } = await supabase
+        .from('site_announcements')
+        .delete()
+        .eq('id', a.id);
+
+      if (error) {
+        deleteBtn.disabled = false;
+        statusEl.textContent = error.code === '42501'
+          ? 'Keine Admin-Berechtigung.'
+          : `Fehler: ${error.message}`;
+        statusEl.className = 'admin-games-status admin-games-status-error';
+        return;
+      }
+
+      await refreshMaintenanceBanner();
+      row.remove();
+    };
+    deleteBtn.addEventListener('click', deleteHandler);
+
+    // Track listeners for cleanup
+    cleanups.push(() => {
+      saveBtn.removeEventListener('click', saveHandler);
+      deleteBtn.removeEventListener('click', deleteHandler);
+      textarea.removeEventListener('input', resetStatus);
+      severitySelect.removeEventListener('change', resetStatus);
+      activeCheck.removeEventListener('change', resetStatus);
+      expiresInput.removeEventListener('change', resetStatus);
+    });
+
+    row.append(textarea, severitySelect, activeLabel, expiresInput, saveBtn, deleteBtn, statusEl);
+    listEl.appendChild(row);
+  }
+
   return function destroy() {
-    // Phase-2-Platzhalter: noch nichts zu cleanen
+    destroyed = true;
+    for (const fn of cleanups) fn();
+    cleanups.length = 0;
   };
 }

--- a/src/pages/datenschutz.js
+++ b/src/pages/datenschutz.js
@@ -1,0 +1,56 @@
+export function mount(container) {
+  const article = document.createElement('article');
+  article.className = 'datenschutz';
+
+  function section(titleText, paragraphs) {
+    const h2 = document.createElement('h2');
+    h2.textContent = titleText;
+    article.appendChild(h2);
+    for (const text of paragraphs) {
+      const p = document.createElement('p');
+      p.textContent = text;
+      article.appendChild(p);
+    }
+  }
+
+  const h1 = document.createElement('h1');
+  h1.textContent = 'Datenschutzerklärung';
+  article.appendChild(h1);
+
+  section('1. Verantwortlicher', [
+    'Dieses Projekt ist ein privates Hobby-Projekt ohne kommerziellen Hintergrund. Für Fragen zum Datenschutz wende dich bitte per E-Mail an: datenschutz@example.com (Platzhalter – Kontaktadresse folgt).',
+  ]);
+
+  section('2. Erhobene Daten', [
+    'Bei der Registrierung und Nutzung des Dienstes werden folgende Daten erhoben: E-Mail-Adresse (Pflichtfeld für die Anmeldung), ein frei wählbarer Anzeigename (Display-Name), Spielstand-Scores sowie die Spieldauer je Runde.',
+    'Weitere personenbezogene Daten werden nicht aktiv erhoben.',
+  ]);
+
+  section('3. Verarbeitung und Dienstleister', [
+    'Die Daten werden über Supabase (https://supabase.com) gespeichert und verarbeitet. Supabase betreibt Server in der EU (AWS Frankfurt). Die Nutzungsbedingungen und Datenschutzrichtlinien von Supabase gelten zusätzlich.',
+    'Die Webanwendung selbst wird statisch über GitHub Pages (https://pages.github.com) ausgeliefert. GitHub kann dabei technische Zugriffsprotokolle (IP-Adresse, Zeitstempel) erfassen; diese werden von GitHub erhoben und unterliegen Githubs Datenschutzrichtlinien.',
+  ]);
+
+  section('4. Speicherdauer', [
+    'Deine Daten werden so lange gespeichert, wie dein Konto existiert. Nach einer Kontolöschung werden alle zugehörigen Scores und Profildaten gelöscht. Wende dich dazu an die oben genannte Kontaktadresse.',
+  ]);
+
+  section('5. Deine Rechte', [
+    'Du hast jederzeit das Recht auf Auskunft über die zu deiner Person gespeicherten Daten, auf Berichtigung unrichtiger Daten sowie auf Löschung deiner Daten. Sende dazu eine formlose E-Mail an die oben genannte Kontaktadresse.',
+  ]);
+
+  section('6. Cookies und lokale Speicherung', [
+    'Diese Anwendung verwendet kein Third-Party-Tracking und keine Werbe-Cookies. Im lokalen Browserspeicher (localStorage) werden ausschließlich technisch notwendige Daten abgelegt: Auth-Session-Token (Supabase) sowie Dismiss-Status für Wartungshinweise (Maintenance-Banner).',
+    'Es werden keine Daten an Werbenetzwerke oder Analyse-Dienste übermittelt.',
+  ]);
+
+  section('7. Stand', [
+    'Stand dieser Datenschutzerklärung: 14.05.2026.',
+  ]);
+
+  container.appendChild(article);
+
+  return function destroy() {
+    // Keine Listener oder Loops zu bereinigen
+  };
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13,6 +13,7 @@
   --border-subtle: rgba(255,255,255,0.08);
   --border:        rgba(255,255,255,0.12);
   --border-strong: rgba(255,255,255,0.20);
+  --warning:       #f6c945;
   --nav-h:         56px;
   --score-strip-h: 48px;
   --dpad-h:        208px;
@@ -1089,4 +1090,78 @@ dialog::backdrop {
   .admin-stats-chart-canvas { height: 220px; }
   .admin-stats-top-tabs { overflow-x: auto; -webkit-overflow-scrolling: touch; }
   .admin-stats-top-tab { white-space: nowrap; }
+}
+
+/* ===== Maintenance Banner ===== */
+.maintenance-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1.25rem;
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.maintenance-banner-msg { flex: 1; min-width: 0; }
+.maintenance-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+.maintenance-banner--info     { background: rgba(127,90,240,0.15); color: var(--text); }
+.maintenance-banner--warning  { background: rgba(246,201,69,0.15); color: var(--text); }
+.maintenance-banner--critical { background: rgba(229,49,112,0.18); color: var(--text); }
+
+/* ===== Site Footer ===== */
+.site-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 2rem;
+}
+.site-footer a { color: var(--text-muted); }
+.site-footer a:hover { color: var(--text); }
+.site-footer-sep { opacity: 0.5; }
+
+/* ===== Datenschutz-Page ===== */
+.datenschutz { max-width: 720px; margin: 0 auto; padding: 1rem 0 3rem; }
+.datenschutz h1 { margin-bottom: 1.5rem; }
+.datenschutz h2 { margin: 2rem 0 0.5rem; font-size: 1.15rem; }
+.datenschutz p  { color: var(--text-muted); margin-bottom: 0.5rem; }
+
+/* ===== Admin – Announcements tab ===== */
+.admin-announcements { display: flex; flex-direction: column; gap: 1rem; }
+.admin-announcements-list { display: flex; flex-direction: column; gap: 0.75rem; }
+.admin-announcements-row {
+  display: grid;
+  grid-template-columns: 1fr 140px 100px 200px auto auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+}
+.admin-announcements-row textarea {
+  min-height: 3em;
+  resize: vertical;
+  padding: 0.5rem 0.75rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+}
+@media (max-width: 768px) {
+  .admin-announcements-row { grid-template-columns: 1fr; }
 }

--- a/src/ui/footer.js
+++ b/src/ui/footer.js
@@ -1,0 +1,30 @@
+export function initFooter(host) {
+  if (host.querySelector('.site-footer')) return;
+
+  const footer = document.createElement('footer');
+  footer.className = 'site-footer';
+
+  const copyright = document.createElement('span');
+  copyright.textContent = '© 2026 GameHub';
+
+  const sep1 = document.createElement('span');
+  sep1.className = 'site-footer-sep';
+  sep1.textContent = '·';
+
+  const datenschutz = document.createElement('a');
+  datenschutz.href = '#/datenschutz';
+  datenschutz.textContent = 'Datenschutz';
+
+  const sep2 = document.createElement('span');
+  sep2.className = 'site-footer-sep';
+  sep2.textContent = '·';
+
+  const github = document.createElement('a');
+  github.href = 'https://github.com/kangsdoteu/claude-game';
+  github.target = '_blank';
+  github.rel = 'noopener noreferrer';
+  github.textContent = 'GitHub';
+
+  footer.append(copyright, sep1, datenschutz, sep2, github);
+  host.appendChild(footer);
+}

--- a/src/ui/maintenance-banner.js
+++ b/src/ui/maintenance-banner.js
@@ -1,0 +1,84 @@
+import { supabase } from '../api/supabase.js';
+
+let cache = null;
+let inflight = null;
+let cacheEpoch = 0;
+let currentHost = null;
+const TTL_MS = 60_000;
+const DISMISS_PREFIX = 'mb:dismissed:';
+const FAIL_OPEN = [];
+
+export async function initMaintenanceBanner(host) {
+  currentHost = host;
+  await renderBanner();
+}
+
+export function invalidateMaintenanceBanner() {
+  cache = null;
+  inflight = null;
+  cacheEpoch++;
+}
+
+export async function refreshMaintenanceBanner() {
+  invalidateMaintenanceBanner();
+  if (currentHost) await renderBanner();
+}
+
+async function fetchAnnouncements() {
+  if (cache && Date.now() < cache.expiresAt) return cache.data;
+  if (inflight) return inflight;
+  const myEpoch = cacheEpoch;
+  inflight = (async () => {
+    try {
+      const { data, error } = await supabase
+        .from('site_announcements')
+        .select('id, message, severity, created_at')
+        .order('created_at', { ascending: false })
+        .limit(5);
+      if (error || !data) return FAIL_OPEN;
+      if (myEpoch === cacheEpoch) cache = { data, expiresAt: Date.now() + TTL_MS };
+      return data;
+    } catch { return FAIL_OPEN; }
+  })();
+  try { return await inflight; } finally { inflight = null; }
+}
+
+async function renderBanner() {
+  // Remove existing
+  const existing = currentHost.querySelector('.maintenance-banner');
+  if (existing) existing.remove();
+
+  const list = await fetchAnnouncements();
+  if (!list || list.length === 0) return;
+
+  // Find first non-dismissed
+  let chosen = null;
+  for (const a of list) {
+    if (!localStorage.getItem(DISMISS_PREFIX + a.id)) { chosen = a; break; }
+  }
+  if (!chosen) return;
+
+  const banner = document.createElement('div');
+  banner.className = `maintenance-banner maintenance-banner--${chosen.severity}`;
+  banner.setAttribute('role', 'status');
+
+  const msg = document.createElement('span');
+  msg.className = 'maintenance-banner-msg';
+  msg.textContent = chosen.message;
+
+  const dismiss = document.createElement('button');
+  dismiss.className = 'maintenance-banner-dismiss';
+  dismiss.setAttribute('aria-label', 'Schließen');
+  dismiss.textContent = '×';
+  dismiss.addEventListener('click', () => {
+    localStorage.setItem(DISMISS_PREFIX + chosen.id, '1');
+    banner.remove();
+  });
+
+  banner.append(msg, dismiss);
+
+  // Insert between nav and main (#app)
+  const app = currentHost.querySelector('#app');
+  if (app) currentHost.insertBefore(banner, app);
+  else currentHost.appendChild(banner);
+}

--- a/supabase/migrations/009_admin_maintenance.sql
+++ b/supabase/migrations/009_admin_maintenance.sql
@@ -1,0 +1,57 @@
+-- Migration 009: Maintenance-Banner – site_announcements-Tabelle
+--
+-- Nummerierungs-Hinweis:
+--   007 ist für Phase 7 (Audit-Log) reserviert,
+--   008 für Phase 8 (Moderation). Diese Migration nimmt 009.
+--
+-- Ausführung: Gesamten Inhalt im Supabase-SQL-Editor einfügen und ausführen.
+
+BEGIN;
+
+-- ============================================================
+-- 1. site_announcements-Tabelle
+-- ============================================================
+
+CREATE TABLE public.site_announcements (
+    id         BIGSERIAL PRIMARY KEY,
+    message    TEXT NOT NULL CHECK (char_length(message) BETWEEN 1 AND 500),
+    severity   TEXT NOT NULL CHECK (severity IN ('info','warning','critical')) DEFAULT 'info',
+    active     BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    created_by UUID REFERENCES public.profiles(id)
+);
+
+-- Partial Index für schnelle Abfragen auf aktive, nicht-abgelaufene Einträge
+CREATE INDEX idx_site_announcements_active_expires
+    ON public.site_announcements (active, expires_at)
+    WHERE active = TRUE;
+
+ALTER TABLE public.site_announcements ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 2. RLS-Policies
+-- ============================================================
+
+CREATE POLICY "site_announcements: public read active"
+    ON public.site_announcements FOR SELECT
+    USING (active = TRUE AND (expires_at IS NULL OR expires_at > NOW()));
+
+CREATE POLICY "site_announcements: admin read all"
+    ON public.site_announcements FOR SELECT
+    USING (public.is_admin());
+
+CREATE POLICY "site_announcements: admin insert"
+    ON public.site_announcements FOR INSERT
+    WITH CHECK (public.is_admin());
+
+CREATE POLICY "site_announcements: admin update"
+    ON public.site_announcements FOR UPDATE
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin());
+
+CREATE POLICY "site_announcements: admin delete"
+    ON public.site_announcements FOR DELETE
+    USING (public.is_admin());
+
+COMMIT;


### PR DESCRIPTION
## Summary

Phase 9 des Admin-Bereichs (Tracking-Issue #49): globaler Maintenance-Banner + Footer + Datenschutz-Page + Admin-Tab zum Verwalten der Banner.

- **Migration 009 (`site_announcements`)**: Tabelle mit `message`/`severity`/`active`/`expires_at`/`created_by`, Partial-Index, fünf RLS-Policies. Public liest nur aktive + nicht-abgelaufene, Admins sehen alle Zeilen und schreiben.
- **`src/ui/maintenance-banner.js`**: globaler Banner, lebt am `<body>` (nicht in `#app`), persistiert über Routenwechsel. TTL-Cache 60 s, Single-Flight, Cache-Epoch gegen Stale-Writes, Fail-Open. Drei Severity-Varianten (info/warning/critical). Dismissible per `localStorage` pro Announcement-ID.
- **`src/ui/footer.js`**: globaler Footer mit `© 2026 GameHub · Datenschutz · GitHub`. Auch am `<body>`, kein Re-Mount bei Routenwechsel.
- **`src/pages/datenschutz.js`** (neue Route `#/datenschutz`): sieben Abschnitte (Verantwortlicher, Daten, Verarbeitung, Speicherdauer, Rechte, Cookies/LocalStorage, Stand). Boilerplate-Text, vom Maintainer anpassbar.
- **`src/pages/admin/announcements.js`** (ersetzt Phase-2-Platzhalter): Create-Form + Liste aller Announcements mit Inline-Edit (textarea, severity-select, active-checkbox, expires_at-datetime, Save + Delete). Nach jeder Mutation `refreshMaintenanceBanner()`.
- **`src/main.js`**: Route registriert, Banner + Footer einmalig in `init()`.
- **CSS**: neues `--warning`-Token, plus `.maintenance-banner`, `.site-footer`, `.datenschutz`, `.admin-announcements`. Mobile-Stacking bei 768 px.

## Architektur-Entscheidungen

- Banner + Footer leben außerhalb von `#app` — Routen-Reset löscht sie nicht, kein Flicker, kein Re-Mount.
- `created_by` wird vom Client **nicht** gesetzt — analog zu Phase 4 (`game_settings.updated_by`). Befüllung gehört in einen späteren DB-Trigger.
- Dismiss-Persistenz an `id` gekoppelt, nicht an `created_at` — ein Severity-Edit triggert den Banner nicht erneut für User, die ihn schon dismissed haben.

## Manuelle Schritte vor Merge

1. Migration `009_admin_maintenance.sql` im Supabase-SQL-Editor einspielen (eine Transaktion, ein Run).
2. Im Admin-Tab „Banner" eine erste Announcement anlegen, um zu testen.

## Test plan

- [x] `npm run build` läuft durch (geprüft, 613 ms; `announcements`-Chunk wuchs auf 5.57 kB, `datenschutz`-Chunk neu mit 2.40 kB)
- [x] Visueller Test: Banner mit warning-Severity, Footer mit drei Links, Datenschutz-Page mit 7 Abschnitten
- [ ] Admin-Tab: Create + Edit + Delete je einmal durchklicken; jedes Mal aktualisiert sich der Banner sofort
- [ ] Banner-Dismiss schließt und bleibt nach Reload weg
- [ ] Mobile (≤ 768 px): Admin-Announcements-Reihen stacken vertikal

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)