### PR TITLE
feat(admin): phase 7 — audit log

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -67,3 +67,23 @@ export async function topPlayers(game, limit = 10) {
   if (error) handleError(error);
   return data ?? [];
 }
+
+export async function logAuditAction(action, { targetType = null, targetId = null, payload = null } = {}) {
+  const { data, error } = await supabase.rpc('admin_log_action', {
+    p_action: action,
+    p_target_type: targetType,
+    p_target_id: targetId,
+    p_payload: payload,
+  });
+  if (error) handleError(error);
+  return data;
+}
+
+export async function listAuditLog({ limit = 100, offset = 0 } = {}) {
+  const { data, error } = await supabase.rpc('admin_list_audit_log', {
+    p_limit: limit,
+    p_offset: offset,
+  });
+  if (error) handleError(error);
+  return data ?? [];
+}

--- a/src/pages/admin/audit.js
+++ b/src/pages/admin/audit.js
@@ -1,12 +1,266 @@
+import { listAuditLog } from '../../api/admin.js';
+
+const LIMIT = 50;
+
+function formatDateTime(val) {
+  if (!val) return '—';
+  const d = new Date(val);
+  const day   = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year  = d.getFullYear();
+  const hh    = String(d.getHours()).padStart(2, '0');
+  const mm    = String(d.getMinutes()).padStart(2, '0');
+  return `${day}.${month}.${year} ${hh}:${mm}`;
+}
+
+function truncatePayload(payload) {
+  if (payload === null || payload === undefined) return '';
+  const str = JSON.stringify(payload);
+  return str.length > 80 ? str.slice(0, 80) + '…' : str;
+}
+
+function buildRow(entry, listeners) {
+  const tr = document.createElement('tr');
+
+  // Zeitstempel
+  const tdTime = document.createElement('td');
+  tdTime.textContent = formatDateTime(entry.created_at);
+  tr.appendChild(tdTime);
+
+  // Admin
+  const tdAdmin = document.createElement('td');
+  tdAdmin.textContent = entry.admin_display_name ?? '—';
+  tr.appendChild(tdAdmin);
+
+  // Aktion
+  const tdAction = document.createElement('td');
+  tdAction.textContent = entry.action ?? '—';
+  tr.appendChild(tdAction);
+
+  // Ziel
+  const tdTarget = document.createElement('td');
+  const parts = [entry.target_type, entry.target_id].filter(Boolean);
+  tdTarget.textContent = parts.length ? parts.join(':') : '—';
+  tr.appendChild(tdTarget);
+
+  // Payload — klickbar
+  const tdPayload = document.createElement('td');
+  const hasPayload = entry.payload !== null && entry.payload !== undefined;
+
+  if (hasPayload) {
+    const summary = document.createElement('span');
+    summary.className = 'admin-audit-payload';
+    summary.textContent = truncatePayload(entry.payload);
+
+    let expanded = false;
+    let preEl = null;
+
+    function onPayloadClick() {
+      expanded = !expanded;
+      if (expanded) {
+        preEl = document.createElement('pre');
+        preEl.className = 'admin-audit-payload-expanded';
+        preEl.textContent = JSON.stringify(entry.payload, null, 2);
+        tdPayload.appendChild(preEl);
+      } else if (preEl) {
+        preEl.remove();
+        preEl = null;
+      }
+    }
+
+    summary.addEventListener('click', onPayloadClick);
+    listeners.push({ el: summary, type: 'click', fn: onPayloadClick });
+    tdPayload.appendChild(summary);
+  } else {
+    tdPayload.textContent = '—';
+  }
+
+  tr.appendChild(tdPayload);
+  return tr;
+}
+
 export function mount(container) {
+  let active = true;
+  let currentOffset = 0;
+  let lastPageSize = 0;
+  let allRows = [];
+  const listeners = [];
+
+  // --- Build skeleton DOM ---
   const section = document.createElement('section');
-  section.className = 'admin-tab admin-tab-audit';
-  const p = document.createElement('p');
-  p.className = 'admin-placeholder-text';
-  p.textContent = 'Audit-Log — folgt in Phase 7.';
-  section.appendChild(p);
+  section.className = 'admin-audit';
+
+  // Toolbar
+  const toolbar = document.createElement('div');
+  toolbar.className = 'admin-audit-toolbar';
+
+  const searchInput = document.createElement('input');
+  searchInput.type = 'search';
+  searchInput.placeholder = 'Filter nach Aktion, Admin oder Ziel …';
+  searchInput.className = 'admin-audit-search';
+  searchInput.title = 'Filter wirkt nur auf aktuelle Seite';
+
+  const pageInfo = document.createElement('span');
+  pageInfo.className = 'admin-audit-page-info';
+
+  toolbar.appendChild(searchInput);
+  toolbar.appendChild(pageInfo);
+
+  // Table
+  const tableWrap = document.createElement('div');
+  tableWrap.className = 'admin-table-wrap';
+
+  const table = document.createElement('table');
+  table.className = 'admin-table';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  for (const label of ['Zeitstempel', 'Admin', 'Aktion', 'Ziel', 'Details']) {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+
+  const tbody = document.createElement('tbody');
+  table.appendChild(thead);
+  table.appendChild(tbody);
+  tableWrap.appendChild(table);
+
+  // Pagination
+  const pagination = document.createElement('div');
+  pagination.className = 'admin-audit-pagination';
+
+  const btnBack = document.createElement('button');
+  btnBack.textContent = '← Zurück';
+  btnBack.disabled = true;
+
+  const pageIndicator = document.createElement('span');
+  pageIndicator.className = 'admin-audit-page-indicator';
+
+  const btnNext = document.createElement('button');
+  btnNext.textContent = 'Weiter →';
+  btnNext.disabled = true;
+
+  pagination.appendChild(btnBack);
+  pagination.appendChild(pageIndicator);
+  pagination.appendChild(btnNext);
+
+  section.appendChild(toolbar);
+  section.appendChild(tableWrap);
+  section.appendChild(pagination);
   container.appendChild(section);
+
+  // --- Helpers ---
+  function setTbodyMessage(text, cls) {
+    tbody.innerHTML = '';
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 5;
+    td.className = cls;
+    td.textContent = text;
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  }
+
+  function applyFilter(query) {
+    const q = query.trim().toLowerCase();
+    tbody.innerHTML = '';
+
+    const visible = q
+      ? allRows.filter(({ entry }) =>
+          (entry.action ?? '').toLowerCase().includes(q) ||
+          (entry.admin_display_name ?? '').toLowerCase().includes(q) ||
+          (entry.target_type ?? '').toLowerCase().includes(q) ||
+          (entry.target_id ?? '').toLowerCase().includes(q)
+        )
+      : allRows;
+
+    if (visible.length === 0) {
+      setTbodyMessage('Keine Einträge auf dieser Seite.', 'admin-empty');
+      return;
+    }
+
+    for (const { row } of visible) {
+      tbody.appendChild(row);
+    }
+  }
+
+  async function loadPage(offset) {
+    currentOffset = offset;
+    searchInput.value = '';
+    btnBack.disabled = true;
+    btnNext.disabled = true;
+    allRows = [];
+
+    const currentPage = Math.floor(offset / LIMIT) + 1;
+    pageIndicator.textContent = `Seite ${currentPage}`;
+    pageInfo.textContent = '';
+
+    setTbodyMessage('Lade Audit-Log …', 'admin-loading');
+
+    let data;
+    try {
+      data = await listAuditLog({ limit: LIMIT, offset });
+    } catch (err) {
+      if (!active) return;
+      setTbodyMessage(`Konnte Audit-Log nicht laden: ${err.message}`, 'admin-error');
+      return;
+    }
+
+    if (!active) return;
+
+    lastPageSize = data.length;
+
+    if (data.length === 0) {
+      setTbodyMessage('Keine Einträge auf dieser Seite.', 'admin-empty');
+    } else {
+      allRows = data.map(entry => ({ entry, row: buildRow(entry, listeners) }));
+      tbody.innerHTML = '';
+      for (const { row } of allRows) {
+        tbody.appendChild(row);
+      }
+    }
+
+    const from = offset + 1;
+    const to   = offset + data.length;
+    pageInfo.textContent = data.length > 0 ? `${from}–${to}` : '';
+    pageIndicator.textContent = `Seite ${currentPage}`;
+
+    btnBack.disabled = offset === 0;
+    btnNext.disabled = lastPageSize < LIMIT;
+  }
+
+  // --- Event handlers ---
+  function onSearch(e) {
+    applyFilter(e.target.value);
+  }
+
+  function onBack() {
+    if (currentOffset === 0) return;
+    loadPage(currentOffset - LIMIT);
+  }
+
+  function onNext() {
+    if (lastPageSize < LIMIT) return;
+    loadPage(currentOffset + LIMIT);
+  }
+
+  searchInput.addEventListener('input', onSearch);
+  btnBack.addEventListener('click', onBack);
+  btnNext.addEventListener('click', onNext);
+
+  // Initial load
+  loadPage(0);
+
   return function destroy() {
-    // Phase-2-Platzhalter: noch nichts zu cleanen
+    active = false;
+    searchInput.removeEventListener('input', onSearch);
+    btnBack.removeEventListener('click', onBack);
+    btnNext.removeEventListener('click', onNext);
+    for (const { el, type, fn } of listeners) {
+      el.removeEventListener(type, fn);
+    }
+    listeners.length = 0;
   };
 }

--- a/src/pages/admin/games.js
+++ b/src/pages/admin/games.js
@@ -1,6 +1,7 @@
 import { getGameSettings, invalidateGameSettings, GAME_LABELS } from '../../ui/game-availability.js';
 import { refreshNavLinkAvailability } from '../../ui/nav.js';
 import { supabase } from '../../api/supabase.js';
+import { logAuditAction } from '../../api/admin.js';
 
 export function mount(container) {
   let destroyed = false;
@@ -121,6 +122,17 @@ async function handleSave(game, enabled, message, saveBtn, statusEl) {
       : `Fehler: ${error.message}`;
     statusEl.className = 'admin-games-status admin-games-status-error';
     return;
+  }
+
+  try {
+    await logAuditAction('toggle_game', {
+      targetType: 'game',
+      targetId: game,
+      payload: { enabled, disabled_message: (message ?? '').trim() || null },
+    });
+  } catch (err) {
+    // Audit-Failure soll den User-flow nicht abbrechen — nur loggen
+    console.warn('Audit-Eintrag fehlgeschlagen', err);
   }
 
   invalidateGameSettings();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1092,6 +1092,7 @@ dialog::backdrop {
   .admin-stats-top-tab { white-space: nowrap; }
 }
 
+<<<<<<< HEAD
 /* ===== Maintenance Banner ===== */
 .maintenance-banner {
   display: flex;
@@ -1164,4 +1165,73 @@ dialog::backdrop {
 }
 @media (max-width: 768px) {
   .admin-announcements-row { grid-template-columns: 1fr; }
+}
+
+/* ===== Admin – Audit-Log tab ===== */
+.admin-audit-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.admin-audit-search {
+  flex: 1;
+  min-width: 180px;
+  max-width: 320px;
+  padding: 0.4rem 0.75rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+}
+
+.admin-audit-page-info { color: var(--text-muted); font-size: 0.875rem; white-space: nowrap; }
+
+.admin-audit-pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.admin-audit-pagination button {
+  padding: 0.4rem 0.85rem;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.admin-audit-pagination button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.admin-audit-pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.admin-audit-page-indicator { color: var(--text-muted); font-size: 0.875rem; }
+
+.admin-audit-payload {
+  font-family: 'Consolas', 'Courier New', monospace;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+.admin-audit-payload-expanded {
+  white-space: pre-wrap;
+  background: var(--surface2);
+  padding: 0.5rem;
+  border-radius: var(--radius);
+  margin: 0.25rem 0;
+  font-family: 'Consolas', 'Courier New', monospace;
+  font-size: 0.8rem;
+  color: var(--text-muted);
 }

--- a/supabase/migrations/007_admin_audit.sql
+++ b/supabase/migrations/007_admin_audit.sql
@@ -1,0 +1,110 @@
+-- 007_admin_audit.sql
+-- Phase 7 (Audit-Log): Tabelle, RLS, RPCs für admin_log_action und admin_list_audit_log.
+-- Manuell im Supabase-SQL-Editor ausführen. Alte Migrationen nicht editieren.
+
+BEGIN;
+
+-- ============================================================
+-- Tabelle
+-- ============================================================
+CREATE TABLE public.admin_audit_log (
+    id          BIGSERIAL PRIMARY KEY,
+    admin_id    UUID NOT NULL REFERENCES public.profiles(id),
+    action      TEXT NOT NULL,
+    target_type TEXT,
+    target_id   TEXT,
+    payload     JSONB,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_admin_audit_log_created ON public.admin_audit_log(created_at DESC);
+CREATE INDEX idx_admin_audit_log_admin   ON public.admin_audit_log(admin_id, created_at DESC);
+
+ALTER TABLE public.admin_audit_log ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- RLS: nur SELECT für Admins; INSERT ausschließlich via SECURITY DEFINER RPC
+-- ============================================================
+CREATE POLICY "admin_audit_log: admin read"
+    ON public.admin_audit_log FOR SELECT USING (public.is_admin());
+
+-- ============================================================
+-- RPC: admin_log_action
+-- Schreibt einen Audit-Eintrag. Nur für authentifizierte Admins.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.admin_log_action(
+    p_action      TEXT,
+    p_target_type TEXT DEFAULT NULL,
+    p_target_id   TEXT DEFAULT NULL,
+    p_payload     JSONB DEFAULT NULL
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_id BIGINT;
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+    IF p_action IS NULL OR length(p_action) = 0 OR length(p_action) > 100 THEN
+        RAISE EXCEPTION 'invalid action' USING ERRCODE = '22023';
+    END IF;
+    INSERT INTO public.admin_audit_log (admin_id, action, target_type, target_id, payload)
+    VALUES (auth.uid(), p_action, p_target_type, p_target_id, p_payload)
+    RETURNING id INTO v_id;
+    RETURN v_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_log_action(TEXT, TEXT, TEXT, JSONB) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_log_action(TEXT, TEXT, TEXT, JSONB) TO authenticated;
+
+-- ============================================================
+-- RPC: admin_list_audit_log
+-- Gibt paginierte Audit-Einträge inkl. Admin-Name zurück.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.admin_list_audit_log(
+    p_limit  INT DEFAULT 100,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    id                 BIGINT,
+    admin_id           UUID,
+    admin_display_name VARCHAR,
+    action             TEXT,
+    target_type        TEXT,
+    target_id          TEXT,
+    payload            JSONB,
+    created_at         TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+    RETURN QUERY
+    SELECT
+        l.id,
+        l.admin_id,
+        p.display_name,
+        l.action,
+        l.target_type,
+        l.target_id,
+        l.payload,
+        l.created_at
+    FROM public.admin_audit_log l
+    LEFT JOIN public.profiles p ON p.id = l.admin_id
+    ORDER BY l.created_at DESC
+    LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_list_audit_log(INT, INT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_list_audit_log(INT, INT) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Phase 7 des Admin-Bereichs (Tracking-Issue #49): Audit-Log für Admin-Aktionen.

- **Migration 007**: `admin_audit_log`-Tabelle mit `admin_id`, `action`, `target_type`, `target_id`, `payload` JSONB. Zwei Indizes für Standard-Abfragen. RLS gibt nur SELECT für Admins frei, kein INSERT/UPDATE/DELETE-Policy — Schreiben ausschließlich via `SECURITY DEFINER`-RPC. Damit ist die Tabelle tamper-sicher: selbst Admins können nur über die RPC schreiben, die `auth.uid()` als `admin_id` erzwingt.
- **RPCs**: `admin_log_action(action, target_type, target_id, payload)` für Inserts und `admin_list_audit_log(limit, offset)` für Reads inkl. Display-Name-Join.
- **`src/api/admin.js`**: zwei neue Helper `logAuditAction()` und `listAuditLog()` analog zum bestehenden Pattern.
- **`src/pages/admin/games.js`**: nach erfolgreichem `game_settings`-Update wird `logAuditAction('toggle_game', ...)` aufgerufen. Audit-Failure ist in try/catch — UI-Flow bleibt unangetastet.
- **`src/pages/admin/audit.js`**: Tabelle mit fünf Spalten (Zeit, Admin, Aktion, Ziel, Details). Pagination wie Phase 3, clientseitige Suche, Payload klappbar (Default: 80-Zeichen-Summary; Click: pretty-printed JSON in `<pre>`).

## Sicherheits-Anker

- Audit-Inserts ausschließlich via `SECURITY DEFINER`-RPC mit `is_admin()`-Guard und `auth.uid()`-Pflicht — keine Client-Spoofing-Möglichkeit.
- Keine `INSERT`/`UPDATE`/`DELETE`-Policy auf der Tabelle = Default-Deny.
- Action-Strings sind validiert (1–100 Zeichen).

## Manuelle Schritte vor Merge

1. Migration `007_admin_audit.sql` im Supabase-SQL-Editor einspielen.
2. Im Admin-Tab „Spiele" einen Toggle durchführen → Eintrag erscheint im Audit-Tab.

## Test plan

- [x] `npm run build` läuft durch (geprüft, 653 ms)
- [ ] Game-Toggle erzeugt Audit-Eintrag mit korrektem Payload
- [ ] Audit-Tab zeigt Liste, sortiert nach `created_at desc`
- [ ] Payload-Cell klappt auf/zu
- [ ] Audit-Failure bricht User-Flow nicht ab (manuell durch RPC-Rename simulierbar)
- [ ] Pagination bei >50 Einträgen

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)