### PR TITLE
feat(admin): phase 8+10 — moderation, soft ban, rate-limit view

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -87,3 +87,46 @@ export async function listAuditLog({ limit = 100, offset = 0 } = {}) {
   if (error) handleError(error);
   return data ?? [];
 }
+
+export async function deleteScore(scoreId, reason = null) {
+  const { error } = await supabase.rpc('admin_delete_score', {
+    p_score_id: scoreId,
+    p_reason: reason,
+  });
+  if (error) handleError(error);
+}
+
+export async function banUser(userId, reason = null) {
+  const { error } = await supabase.rpc('admin_ban_user', {
+    p_user_id: userId,
+    p_reason: reason,
+  });
+  if (error) handleError(error);
+}
+
+export async function unbanUser(userId) {
+  const { error } = await supabase.rpc('admin_unban_user', {
+    p_user_id: userId,
+  });
+  if (error) handleError(error);
+}
+
+export async function rateLimitRecent(hours = 1) {
+  const { data, error } = await supabase.rpc('admin_rate_limit_recent', {
+    p_hours: hours,
+  });
+  if (error) handleError(error);
+  return data ?? [];
+}
+
+export async function listRecentScores({ limit = 50, offset = 0, game = null } = {}) {
+  let query = supabase
+    .from('scores')
+    .select('id, game, score, duration_seconds, created_at, user_id, profiles(display_name)')
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+  if (game) query = query.eq('game', game);
+  const { data, error } = await query;
+  if (error) handleError(error);
+  return data ?? [];
+}

--- a/src/pages/admin/moderation.js
+++ b/src/pages/admin/moderation.js
@@ -1,12 +1,489 @@
+import { rateLimitRecent, banUser, listRecentScores, deleteScore, listUsers, unbanUser, logAuditAction } from '../../api/admin.js';
+
+// Audit-Wrapper: Failure darf User-Flow nie abbrechen
+async function audit(action, opts) {
+  try { await logAuditAction(action, opts); }
+  catch (err) { console.warn('Audit-Eintrag fehlgeschlagen', err); }
+}
+
+const GAME_LABELS = {
+  tetris:         'Tetris',
+  snake:          'Snake',
+  dinos_realtime: 'Dinos RT',
+  dinos_turn:     'Dinos Turn',
+};
+
+const SCORE_GAMES = [null, 'tetris', 'snake', 'dinos_realtime', 'dinos_turn'];
+const SCORE_GAME_LABELS = ['Alle', 'Tetris', 'Snake', 'Dinos RT', 'Dinos Turn'];
+const SCORE_LIMIT = 50;
+
+function formatDate(val) {
+  if (!val) return '—';
+  return new Date(val).toLocaleString('de-DE');
+}
+
+function formatDuration(secs) {
+  if (!secs && secs !== 0) return '—';
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+function el(tag, cls) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  return e;
+}
+
+function makeSectionHeader(title) {
+  const header = el('div', 'admin-mod-section-header');
+  const h2 = el('h2');
+  h2.textContent = title;
+  header.appendChild(h2);
+  return header;
+}
+
+function makeEmptyRow(text, colSpan) {
+  const tr = el('tr');
+  const td = el('td', 'admin-mod-empty');
+  td.colSpan = colSpan;
+  td.textContent = text;
+  tr.appendChild(td);
+  return tr;
+}
+
+function makeTable(headers) {
+  const wrap = el('div', 'admin-table-wrap');
+  const table = el('table', 'admin-table');
+  const thead = el('thead');
+  const headerRow = el('tr');
+  for (const label of headers) {
+    const th = el('th');
+    th.textContent = label;
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  const tbody = el('tbody');
+  table.appendChild(thead);
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+  return { wrap, tbody };
+}
+
 export function mount(container) {
-  const section = document.createElement('section');
-  section.className = 'admin-tab admin-tab-moderation';
-  const p = document.createElement('p');
-  p.className = 'admin-placeholder-text';
-  p.textContent = 'Moderation — folgt in Phase 8.';
-  section.appendChild(p);
-  container.appendChild(section);
+  let active = true;
+  const listeners = [];
+
+  function on(target, event, handler) {
+    target.addEventListener(event, handler);
+    listeners.push({ target, event, handler });
+  }
+
+  // ============================================================
+  // Root
+  // ============================================================
+  const root = el('div', 'admin-moderation');
+  container.appendChild(root);
+
+  // ============================================================
+  // Section 1: Verdächtige Aktivität (Phase 10)
+  // ============================================================
+  const secActivity = el('div', 'admin-mod-section');
+  const activityHeader = makeSectionHeader('Verdächtige Aktivität (letzte Stunde)');
+
+  const btnRefreshActivity = el('button', 'btn-ghost admin-mod-action-btn');
+  btnRefreshActivity.textContent = 'Neu laden';
+  activityHeader.appendChild(btnRefreshActivity);
+
+  secActivity.appendChild(activityHeader);
+
+  const { wrap: actWrap, tbody: actTbody } = makeTable(['Spieler', 'Scores', 'Letzter Score', 'Aktion']);
+  secActivity.appendChild(actWrap);
+  root.appendChild(secActivity);
+
+  // Inline-Ban-Form state per row (userId → form-el or null)
+  let banForms = {};
+
+  async function loadActivity() {
+    actTbody.innerHTML = '';
+    const loadRow = makeEmptyRow('Lade …', 4);
+    loadRow.firstChild.className = 'admin-loading';
+    actTbody.appendChild(loadRow);
+
+    let data;
+    try {
+      data = await rateLimitRecent(1);
+    } catch (err) {
+      if (!active) return;
+      actTbody.innerHTML = '';
+      actTbody.appendChild(makeEmptyRow(`Fehler: ${err.message}`, 4));
+      return;
+    }
+    if (!active) return;
+
+    banForms = {};
+    actTbody.innerHTML = '';
+
+    if (data.length === 0) {
+      actTbody.appendChild(makeEmptyRow('Keine auffällige Aktivität.', 4));
+      return;
+    }
+
+    for (const row of data) {
+      renderActivityRow(row);
+    }
+  }
+
+  function renderActivityRow(row) {
+    const tr = el('tr');
+    tr.dataset.userId = row.user_id;
+
+    const tdName = el('td');
+    tdName.textContent = row.display_name ?? '—';
+    const tdCount = el('td', 'col-num');
+    tdCount.textContent = String(row.score_count);
+    const tdLast = el('td');
+    tdLast.textContent = formatDate(row.last_at);
+
+    const tdAction = el('td');
+    const banBtn = el('button', 'btn-ghost admin-mod-action-btn admin-mod-action-btn--danger');
+    banBtn.textContent = 'Bannen';
+
+    on(banBtn, 'click', () => {
+      if (banForms[row.user_id]) return;
+      const formEl = buildInlineBanForm(row.user_id, tr, tdAction, banBtn, () => loadActivity());
+      banForms[row.user_id] = formEl;
+    });
+
+    tdAction.appendChild(banBtn);
+    tr.appendChild(tdName);
+    tr.appendChild(tdCount);
+    tr.appendChild(tdLast);
+    tr.appendChild(tdAction);
+    actTbody.appendChild(tr);
+  }
+
+  function buildInlineBanForm(userId, tr, tdAction, banBtn, onSuccess) {
+    banBtn.disabled = true;
+
+    // Insert extra row below for the inline form
+    const formTr = el('tr');
+    formTr.className = 'admin-mod-ban-form-row';
+    const formTd = el('td');
+    formTd.colSpan = 4;
+    formTd.style.padding = '0.5rem 0.75rem';
+
+    const input = el('input');
+    input.type = 'text';
+    input.placeholder = 'Grund (optional, max. 500 Zeichen)';
+    input.maxLength = 500;
+    input.style.cssText = 'width:100%;max-width:400px;padding:0.35rem 0.5rem;background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font:inherit;margin-right:0.5rem;';
+
+    const confirmBtn = el('button', 'btn-ghost admin-mod-action-btn admin-mod-action-btn--danger');
+    confirmBtn.textContent = 'Bestätigen';
+    confirmBtn.style.marginRight = '0.4rem';
+
+    const cancelBtn = el('button', 'btn-ghost admin-mod-action-btn');
+    cancelBtn.textContent = 'Abbrechen';
+
+    const statusSpan = el('span');
+    statusSpan.style.cssText = 'margin-left:0.5rem;font-size:0.85rem;';
+
+    formTd.appendChild(input);
+    formTd.appendChild(confirmBtn);
+    formTd.appendChild(cancelBtn);
+    formTd.appendChild(statusSpan);
+    formTr.appendChild(formTd);
+
+    if (tr.nextSibling) {
+      actTbody.insertBefore(formTr, tr.nextSibling);
+    } else {
+      actTbody.appendChild(formTr);
+    }
+
+    function cleanup() {
+      delete banForms[userId];
+      banBtn.disabled = false;
+      formTr.remove();
+    }
+
+    on(cancelBtn, 'click', cleanup);
+
+    on(confirmBtn, 'click', async () => {
+      confirmBtn.disabled = true;
+      cancelBtn.disabled = true;
+      statusSpan.textContent = 'Wird gespeichert …';
+      statusSpan.style.color = 'var(--text-muted)';
+      const reason = input.value.trim() || null;
+      try {
+        await banUser(userId, reason);
+        await audit('ban_user', { targetType: 'user', targetId: userId, payload: { reason } });
+        statusSpan.textContent = 'Gesperrt.';
+        statusSpan.style.color = 'var(--success)';
+        setTimeout(() => {
+          if (!active) return;
+          cleanup();
+          onSuccess();
+        }, 800);
+      } catch (err) {
+        statusSpan.textContent = `Fehler: ${err.message}`;
+        statusSpan.style.color = 'var(--danger)';
+        confirmBtn.disabled = false;
+        cancelBtn.disabled = false;
+      }
+    });
+
+    return formTr;
+  }
+
+  on(btnRefreshActivity, 'click', loadActivity);
+
+  // ============================================================
+  // Section 2: Letzte Scores (Phase 8)
+  // ============================================================
+  const secScores = el('div', 'admin-mod-section');
+  const scoresHeader = makeSectionHeader('Letzte Scores');
+
+  // Game-Tabs
+  const gameTabs = el('div', 'admin-mod-game-tabs');
+  let selectedGame = null;
+  let scoreOffset = 0;
+  let lastScorePageSize = 0;
+
+  const gameTabBtns = SCORE_GAMES.map((game, i) => {
+    const btn = el('button', 'admin-mod-game-tab' + (game === selectedGame ? ' active' : ''));
+    btn.textContent = SCORE_GAME_LABELS[i];
+    btn.dataset.game = game ?? '';
+    gameTabs.appendChild(btn);
+    return btn;
+  });
+
+  scoresHeader.appendChild(gameTabs);
+  secScores.appendChild(scoresHeader);
+
+  const { wrap: scoreWrap, tbody: scoreTbody } = makeTable(['Datum', 'Spieler', 'Spiel', 'Score', 'Dauer', 'Aktion']);
+  secScores.appendChild(scoreWrap);
+
+  // Pagination
+  const scorePagination = el('div', 'admin-users-pagination');
+  const scoreBtnBack = el('button');
+  scoreBtnBack.textContent = '← Zurück';
+  scoreBtnBack.disabled = true;
+  const scorePageIndicator = el('span', 'admin-users-page-indicator');
+  const scoreBtnNext = el('button');
+  scoreBtnNext.textContent = 'Weiter →';
+  scoreBtnNext.disabled = true;
+  scorePagination.appendChild(scoreBtnBack);
+  scorePagination.appendChild(scorePageIndicator);
+  scorePagination.appendChild(scoreBtnNext);
+  secScores.appendChild(scorePagination);
+  root.appendChild(secScores);
+
+  async function loadScores(offset) {
+    scoreOffset = offset;
+    scoreTbody.innerHTML = '';
+    scoreBtnBack.disabled = true;
+    scoreBtnNext.disabled = true;
+
+    const page = Math.floor(offset / SCORE_LIMIT) + 1;
+    scorePageIndicator.textContent = `Seite ${page}`;
+
+    const loadRow = makeEmptyRow('Lade …', 6);
+    loadRow.firstChild.className = 'admin-loading';
+    scoreTbody.appendChild(loadRow);
+
+    let data;
+    try {
+      data = await listRecentScores({ limit: SCORE_LIMIT, offset, game: selectedGame });
+    } catch (err) {
+      if (!active) return;
+      scoreTbody.innerHTML = '';
+      scoreTbody.appendChild(makeEmptyRow(`Fehler: ${err.message}`, 6));
+      return;
+    }
+    if (!active) return;
+
+    lastScorePageSize = data.length;
+    scoreTbody.innerHTML = '';
+
+    if (data.length === 0) {
+      scoreTbody.appendChild(makeEmptyRow('Keine Scores.', 6));
+    } else {
+      for (const score of data) {
+        scoreTbody.appendChild(buildScoreRow(score));
+      }
+    }
+
+    scoreBtnBack.disabled = offset === 0;
+    scoreBtnNext.disabled = lastScorePageSize < SCORE_LIMIT;
+  }
+
+  function buildScoreRow(score) {
+    const tr = el('tr');
+    const displayName = score.profiles?.display_name ?? '—';
+    const gameLabel = GAME_LABELS[score.game] ?? score.game;
+
+    const cells = [
+      formatDate(score.created_at),
+      displayName,
+      gameLabel,
+      String(score.score),
+      formatDuration(score.duration_seconds),
+    ];
+
+    for (const text of cells) {
+      const td = el('td');
+      td.textContent = text;
+      tr.appendChild(td);
+    }
+
+    const tdAction = el('td');
+    const delBtn = el('button', 'btn-ghost admin-mod-action-btn admin-mod-action-btn--danger');
+    delBtn.textContent = 'Löschen';
+
+    on(delBtn, 'click', async () => {
+      const reason = window.prompt('Grund für Löschung (optional):');
+      if (reason === null) return; // abgebrochen
+      delBtn.disabled = true;
+      try {
+        const trimmedReason = reason.trim() || null;
+        await deleteScore(score.id, trimmedReason);
+        await audit('delete_score', { targetType: 'score', targetId: score.id, payload: { reason: trimmedReason } });
+        tr.remove();
+      } catch (err) {
+        delBtn.disabled = false;
+        window.alert(`Fehler: ${err.message}`);
+      }
+    });
+
+    tdAction.appendChild(delBtn);
+    tr.appendChild(tdAction);
+    return tr;
+  }
+
+  // Tab-Klick
+  for (let i = 0; i < gameTabBtns.length; i++) {
+    const btn = gameTabBtns[i];
+    const game = SCORE_GAMES[i];
+    on(btn, 'click', () => {
+      for (const b of gameTabBtns) b.classList.remove('active');
+      btn.classList.add('active');
+      selectedGame = game;
+      loadScores(0);
+    });
+  }
+
+  on(scoreBtnBack, 'click', () => {
+    if (scoreOffset === 0) return;
+    loadScores(scoreOffset - SCORE_LIMIT);
+  });
+  on(scoreBtnNext, 'click', () => {
+    if (lastScorePageSize < SCORE_LIMIT) return;
+    loadScores(scoreOffset + SCORE_LIMIT);
+  });
+
+  // ============================================================
+  // Section 3: Gebannte Nutzer
+  // ============================================================
+  const secBanned = el('div', 'admin-mod-section');
+  const bannedHeader = makeSectionHeader('Gesperrte Nutzer');
+
+  const btnRefreshBanned = el('button', 'btn-ghost admin-mod-action-btn');
+  btnRefreshBanned.textContent = 'Neu laden';
+  bannedHeader.appendChild(btnRefreshBanned);
+
+  secBanned.appendChild(bannedHeader);
+
+  const { wrap: bannedWrap, tbody: bannedTbody } = makeTable(['Spieler', 'Gesperrt am', 'Grund', 'Aktion']);
+  secBanned.appendChild(bannedWrap);
+  root.appendChild(secBanned);
+
+  async function loadBanned() {
+    bannedTbody.innerHTML = '';
+    const loadRow = makeEmptyRow('Lade …', 4);
+    loadRow.firstChild.className = 'admin-loading';
+    bannedTbody.appendChild(loadRow);
+
+    let data;
+    try {
+      // Fetch a large set and filter client-side – efficient for < 1000 users
+      data = await listUsers({ limit: 1000, offset: 0 });
+    } catch (err) {
+      if (!active) return;
+      bannedTbody.innerHTML = '';
+      bannedTbody.appendChild(makeEmptyRow(`Fehler: ${err.message}`, 4));
+      return;
+    }
+    if (!active) return;
+
+    const banned = data.filter(u => u.banned_at);
+    bannedTbody.innerHTML = '';
+
+    if (banned.length === 0) {
+      bannedTbody.appendChild(makeEmptyRow('Keine gesperrten Nutzer.', 4));
+      return;
+    }
+
+    for (const user of banned) {
+      bannedTbody.appendChild(buildBannedRow(user));
+    }
+  }
+
+  function buildBannedRow(user) {
+    const tr = el('tr');
+    tr.dataset.userId = user.id;
+
+    const tdName = el('td');
+    tdName.textContent = user.display_name ?? '—';
+    const tdAt = el('td');
+    tdAt.textContent = formatDate(user.banned_at);
+    const tdReason = el('td');
+    tdReason.textContent = user.banned_reason ?? '—';
+
+    const tdAction = el('td');
+    const unbanBtn = el('button', 'btn-ghost admin-mod-action-btn');
+    unbanBtn.textContent = 'Entsperren';
+
+    on(unbanBtn, 'click', async () => {
+      unbanBtn.disabled = true;
+      try {
+        await unbanUser(user.id);
+        await audit('unban_user', { targetType: 'user', targetId: user.id });
+        tr.remove();
+        // If table is now empty, show placeholder
+        if (bannedTbody.children.length === 0) {
+          bannedTbody.appendChild(makeEmptyRow('Keine gesperrten Nutzer.', 4));
+        }
+      } catch (err) {
+        unbanBtn.disabled = false;
+        window.alert(`Fehler: ${err.message}`);
+      }
+    });
+
+    tdAction.appendChild(unbanBtn);
+    tr.appendChild(tdName);
+    tr.appendChild(tdAt);
+    tr.appendChild(tdReason);
+    tr.appendChild(tdAction);
+    return tr;
+  }
+
+  on(btnRefreshBanned, 'click', loadBanned);
+
+  // ============================================================
+  // Initial loads
+  // ============================================================
+  loadActivity();
+  loadScores(0);
+  loadBanned();
+
+  // ============================================================
+  // Destroy
+  // ============================================================
   return function destroy() {
-    // Phase-2-Platzhalter: noch nichts zu cleanen
+    active = false;
+    for (const { target, event, handler } of listeners) {
+      target.removeEventListener(event, handler);
+    }
   };
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1092,7 +1092,6 @@ dialog::backdrop {
   .admin-stats-top-tab { white-space: nowrap; }
 }
 
-<<<<<<< HEAD
 /* ===== Maintenance Banner ===== */
 .maintenance-banner {
   display: flex;
@@ -1235,3 +1234,16 @@ dialog::backdrop {
   font-size: 0.8rem;
   color: var(--text-muted);
 }
+
+/* ===== Admin – Moderation tab ===== */
+.admin-moderation { display: flex; flex-direction: column; gap: 2rem; }
+.admin-mod-section { background: var(--surface); border: 1px solid var(--border-subtle); border-radius: var(--radius); padding: 1rem 1.25rem; }
+.admin-mod-section-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+.admin-mod-section h2 { margin: 0; font-size: 1rem; color: var(--text); }
+.admin-mod-game-tabs { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+.admin-mod-game-tab { background: transparent; border: none; padding: 0.4rem 0.85rem; border-radius: var(--radius); color: var(--text-muted); font: inherit; cursor: pointer; }
+.admin-mod-game-tab.active { background: var(--surface2); color: var(--accent); }
+.admin-mod-action-btn { padding: 0.35rem 0.75rem; font-size: 0.85rem; }
+.admin-mod-action-btn--danger { color: var(--danger); }
+.admin-mod-action-btn--danger:hover:not(:disabled) { border-color: var(--danger); }
+.admin-mod-empty { color: var(--text-muted); padding: 1rem; text-align: center; }

--- a/supabase/migrations/008_admin_moderation.sql
+++ b/supabase/migrations/008_admin_moderation.sql
@@ -1,0 +1,235 @@
+-- Migration 008: Admin – Score-Moderation + Soft-Ban
+--
+-- Führt folgende Änderungen durch:
+--   1. profiles: banned_at, banned_reason (Soft-Ban)
+--   2. scores Insert-Policy: gebannte User dürfen keine Scores submitten
+--   3. RPC admin_delete_score
+--   4. RPCs admin_ban_user, admin_unban_user
+--   5. RPC admin_rate_limit_recent
+--   6. View admin_users_overview + RPC admin_list_users neu erstellt mit neuen Spalten
+--
+-- Ausführung im Supabase-SQL-Editor: vollständigen Inhalt als einen Run einfügen.
+-- DROP POLICY + CREATE POLICY liegen in einer Transaktion – kein Default-Deny-Fenster.
+
+BEGIN;
+
+-- ============================================================
+-- 1. profiles: Soft-Ban-Spalten
+-- ============================================================
+
+ALTER TABLE public.profiles
+    ADD COLUMN banned_at     TIMESTAMPTZ,
+    ADD COLUMN banned_reason TEXT CHECK (banned_reason IS NULL OR char_length(banned_reason) <= 500);
+
+CREATE INDEX idx_profiles_banned
+    ON public.profiles(banned_at)
+    WHERE banned_at IS NOT NULL;
+
+-- ============================================================
+-- 2. scores Insert-Policy: Ban-Check ergänzen
+--    DROP + CREATE in derselben Transaktion, damit kein Default-Deny-Fenster entsteht.
+-- ============================================================
+
+DROP POLICY "scores: insert own" ON public.scores;
+
+CREATE POLICY "scores: insert own"
+    ON public.scores FOR INSERT WITH CHECK (
+        auth.uid() IS NOT NULL
+        -- Score limits per game
+        AND (game <> 'tetris'          OR score <= 10000000)
+        AND (game <> 'snake'           OR score <= 100000)
+        AND (game <> 'dinos_realtime'  OR score <= 400)
+        AND (game <> 'dinos_turn'      OR score <= 5000)
+        -- Score/time plausibility (global)
+        AND (score::float / duration_seconds) <= 100000
+        -- dinos_realtime: kalibriert auf Phase-0-Formel (max ~0.5 Pkt/s legitim)
+        AND (game <> 'dinos_realtime' OR (score::float / duration_seconds) <= 0.4)
+        -- Rate limiting
+        AND public.count_recent_scores(auth.uid(), 3600) < 10
+        AND public.count_recent_scores(auth.uid(), 60)   < 2
+        -- Gebannte User dürfen keine Scores submitten
+        AND (SELECT banned_at FROM public.profiles WHERE id = auth.uid()) IS NULL
+    );
+
+-- ============================================================
+-- 3. RPC admin_delete_score
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.admin_delete_score(p_score_id UUID, p_reason TEXT DEFAULT NULL)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+    DELETE FROM public.scores WHERE id = p_score_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_delete_score(UUID, TEXT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_delete_score(UUID, TEXT) TO authenticated;
+
+-- ============================================================
+-- 4. RPCs admin_ban_user, admin_unban_user
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.admin_ban_user(p_user_id UUID, p_reason TEXT DEFAULT NULL)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+    -- Self-Ban verhindern: ein Admin darf sich nicht selbst sperren
+    IF p_user_id = auth.uid() THEN
+        RAISE EXCEPTION 'cannot ban self' USING ERRCODE = '22023';
+    END IF;
+    UPDATE public.profiles
+        SET banned_at     = NOW(),
+            banned_reason = p_reason
+        WHERE id = p_user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_unban_user(p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+    UPDATE public.profiles
+        SET banned_at     = NULL,
+            banned_reason = NULL
+        WHERE id = p_user_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_ban_user(UUID, TEXT)  FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_ban_user(UUID, TEXT)  TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.admin_unban_user(UUID) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_unban_user(UUID) TO authenticated;
+
+-- ============================================================
+-- 5. RPC admin_rate_limit_recent
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.admin_rate_limit_recent(p_hours INT DEFAULT 1)
+RETURNS TABLE (
+    user_id      UUID,
+    display_name VARCHAR,
+    score_count  BIGINT,
+    last_at      TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+    RETURN QUERY
+    SELECT
+        s.user_id,
+        p.display_name,
+        COUNT(*) AS score_count,
+        MAX(s.created_at) AS last_at
+    FROM public.scores s
+    JOIN public.profiles p ON p.id = s.user_id
+    WHERE s.created_at > NOW() - (p_hours || ' hours')::INTERVAL
+    GROUP BY s.user_id, p.display_name
+    HAVING COUNT(*) >= 3
+    ORDER BY COUNT(*) DESC;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_rate_limit_recent(INT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_rate_limit_recent(INT) TO authenticated;
+
+-- ============================================================
+-- 6. admin_users_overview View neu erstellen (mit banned_at, banned_reason)
+--    + admin_list_users RPC anpassen
+-- ============================================================
+
+DROP VIEW public.admin_users_overview;
+
+CREATE VIEW public.admin_users_overview
+WITH (security_invoker = true)
+AS
+SELECT
+    p.id,
+    p.display_name,
+    u.email,
+    u.created_at          AS registered_at,
+    u.last_sign_in_at,
+    p.is_admin,
+    COALESCE(sc.score_count, 0) AS score_count,
+    sc.last_score_at,
+    p.banned_at,
+    p.banned_reason
+FROM public.profiles p
+JOIN auth.users u ON u.id = p.id
+LEFT JOIN (
+    SELECT
+        user_id,
+        COUNT(*)        AS score_count,
+        MAX(created_at) AS last_score_at
+    FROM public.scores
+    GROUP BY user_id
+) sc ON sc.user_id = p.id;
+
+CREATE OR REPLACE FUNCTION public.admin_list_users(
+    p_limit  INT DEFAULT 100,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    id              UUID,
+    display_name    VARCHAR,
+    email           TEXT,
+    registered_at   TIMESTAMPTZ,
+    last_sign_in_at TIMESTAMPTZ,
+    is_admin        BOOLEAN,
+    score_count     BIGINT,
+    last_score_at   TIMESTAMPTZ,
+    banned_at       TIMESTAMPTZ,
+    banned_reason   TEXT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NOT public.is_admin() THEN
+        RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        v.id,
+        v.display_name,
+        v.email,
+        v.registered_at,
+        v.last_sign_in_at,
+        v.is_admin,
+        v.score_count,
+        v.last_score_at,
+        v.banned_at,
+        v.banned_reason
+    FROM public.admin_users_overview v
+    ORDER BY v.registered_at DESC
+    LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_list_users(INT, INT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.admin_list_users(INT, INT) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Phase 8 (Score-Moderation + Soft-Ban) und Phase 10 (Rate-Limit-Sicht) gebündelt — beide leben im Moderation-Tab.

- **Migration 008**: `profiles.banned_at` + `banned_reason`, Scores-Insert-Policy mit Ban-Check (DROP/CREATE in derselben Transaktion), vier neue RPCs (`admin_delete_score`, `admin_ban_user` mit Self-Ban-Guard, `admin_unban_user`, `admin_rate_limit_recent`). View `admin_users_overview` + RPC `admin_list_users` recreated mit den neuen Ban-Spalten.
- **`src/api/admin.js`**: 5 neue Helper (`deleteScore`, `banUser`, `unbanUser`, `rateLimitRecent`, `listRecentScores`).
- **`src/pages/admin/moderation.js`** (ersetzt Phase-2-Platzhalter): drei vertikale Sektionen
  - **Verdächtige Aktivität**: Tabelle der User mit ≥3 Scores in der letzten Stunde, Inline-Ban-Formular pro Zeile.
  - **Letzte Scores**: Spiel-Tabs als Selector, paginierte Score-Liste, Löschen mit Reason-Prompt.
  - **Gesperrte Nutzer**: Liste aller `banned_at IS NOT NULL`, Entsperren auf Click.
- **TODO-Kommentare**: an drei Stellen `// TODO Phase 7: logAuditAction(...)` — Audit-Verkabelung wird in einem Follow-up nach Merge von PR #57 (Phase 7) ergänzt.

## Sicherheits-Anker

- Self-Ban verhindert (Admin kann sich nicht selbst sperren).
- Gebannte User können keine Scores mehr submitten (RLS-Policy mit Ban-Check).
- Score-Delete nur via `SECURITY DEFINER`-RPC, keine DELETE-Policy auf `scores`.
- Soft-Ban only: User-Account bleibt erhalten, `banned_at` als Timestamp.

## Manuelle Schritte vor Merge

1. Migration `008_admin_moderation.sql` einspielen.
2. Im Moderation-Tab probeweise einen Score löschen / einen Test-User bannen + entbannen.

## Test plan

- [x] `npm run build` läuft durch (geprüft, 615 ms)
- [ ] Score löschen: Reason-Prompt erscheint, Eintrag verschwindet
- [ ] User bannen: gebannter User kann keine neuen Scores submitten (Insert-Policy)
- [ ] Self-Ban-Versuch wirft Fehler
- [ ] Rate-Limit-Sicht zeigt User mit auffällig vielen Scores
- [ ] Audit-Wires werden in Follow-up-PR nach Phase 7 ergänzt

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)