### PR TITLE
fix(admin): migration 008 — drop admin_list_users before recreating it

### DIFF
--- a/supabase/migrations/008_admin_moderation.sql
+++ b/supabase/migrations/008_admin_moderation.sql
@@ -185,7 +185,12 @@ LEFT JOIN (
     GROUP BY user_id
 ) sc ON sc.user_id = p.id;
 
-CREATE OR REPLACE FUNCTION public.admin_list_users(
+-- DROP zwingend vor CREATE — CREATE OR REPLACE darf in Postgres den Return-Type
+-- einer existierenden Funktion nicht ändern (42P13). admin_list_users existiert
+-- aus 006 mit 8 Spalten; wir erweitern auf 10.
+DROP FUNCTION IF EXISTS public.admin_list_users(INT, INT);
+
+CREATE FUNCTION public.admin_list_users(
     p_limit  INT DEFAULT 100,
     p_offset INT DEFAULT 0
 )


### PR DESCRIPTION
## Summary

Migration `008_admin_moderation.sql` schlägt im Supabase-SQL-Editor fehl:

```
ERROR: 42P13: cannot change return type of existing function
DETAIL: Row type defined by OUT parameters is different.
HINT:  Use DROP FUNCTION admin_list_users(integer,integer) first.
```

Ursache: `006_admin_core.sql` erstellt `admin_list_users(INT, INT)` mit 8 Return-Spalten. 008 versucht, sie via `CREATE OR REPLACE` auf 10 Spalten zu erweitern (`banned_at`, `banned_reason` ergänzt). Postgres erlaubt das nicht — die Return-Type-Signatur ist Teil der Function-Identity.

Fix: ein `DROP FUNCTION IF EXISTS public.admin_list_users(INT, INT);` direkt vor dem `CREATE`. Idempotent in beiden Fällen:
- **Fresh-Install** (006 lief, 008 noch nie): Funktion aus 006 wird gedroppt, neu erstellt.
- **Failed-Install** (008 lief, rollback): Funktion ist noch im 006-Zustand, wird gedroppt, neu erstellt.

`CREATE OR REPLACE` wird zu plain `CREATE`, weil der DROP davor garantiert, dass nichts existiert.

## CLAUDE.md-Hinweis

CLAUDE.md verbietet das Editieren bestehender Migrationen („Alte Migrationen sind eingespielt → nie nachträglich editieren"). Diese Migration ist nirgends erfolgreich angewendet worden (BEGIN/COMMIT rollte alles zurück) — der Maintainer hat das Editieren explizit freigegeben, weil ein nachgereichtes 010 die Migrations-Folder-Reihenfolge unnötig verkompliziert hätte.

## Test plan

- [ ] Migration `008_admin_moderation.sql` im Supabase-SQL-Editor einspielen → läuft fehlerfrei durch
- [ ] Admin-Tab „Moderation" zeigt drei Sektionen, lädt Daten
- [ ] `admin_list_users`-RPC liefert die zwei neuen Spalten

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)